### PR TITLE
Add unit tests for oas.console_factory

### DIFF
--- a/oas_tools/oas.py
+++ b/oas_tools/oas.py
@@ -36,7 +36,7 @@ def short_filename(long: str) -> str:
     return Path(long).name
 
 
-def console_factory() -> Console:  # pragma: no cover
+def console_factory() -> Console:
     """Utility to consolidate creation/initialization of Console.
 
     A little hacky here... Allow terminal width to be set directly by an environment variable, or

--- a/tests/test_oas.py
+++ b/tests/test_oas.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -8,6 +9,7 @@ import pytest
 import typer
 
 from oas_tools.oas import DisplayOption
+from oas_tools.oas import console_factory
 from oas_tools.oas import content_type_list
 from oas_tools.oas import diff
 from oas_tools.oas import info
@@ -33,6 +35,24 @@ from .helpers import asset_filename
 PET_YAML = asset_filename("pet.yaml")
 PET2_YAML = asset_filename("pet2.yaml")
 PET3_YAML = asset_filename("pet3.yaml")
+
+
+#################################################
+# Utilities
+
+def test_console_factory() -> None:
+    # when running the tests, the PYTEST_VERSION is defined by default
+    console = console_factory()
+    assert 3000 == console.width
+
+    with mock.patch.dict(os.environ, {"TERMINAL_WIDTH": "12"}):
+        console = console_factory()
+        assert 12 == console.width
+
+    # using default width for the platform, so it seems to vary
+    with mock.patch.dict(os.environ, {}, clear=True):
+        console = console_factory()
+        assert console.width != 3000
 
 
 #################################################


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

The `oas.console_factory()` had been uncovered in testing, and this fixes that.

## CHANGES
<!-- Please explain at a high-level the changes. -->

Remove the `pragma: no cover`.
Add a unit test to hit all the code paths for `oas.console_factory()`

## NOTES

The `oas.console_factory()` remains separate from the `cli_gen._console.console_factory()` so that the parent does not depend on the children, and the `_console` version is available for copy/test in generated projects.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->