### PR TITLE
Add support for additional content-types

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,5 +4,4 @@ This captures some of the tasks to be done. The intention is to keep it updated,
 
 
 * Security code - enhance the code generation to handle different security schemas. Currently, it only handles an API key.
-* Different media types - effectively, everything is assumed to be `application/json`. Should provide better ways of uploading/downloading files.
 * Additional examples - helps with diversity of OAS methods

--- a/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/_display.py
+++ b/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/_display.py
@@ -296,6 +296,10 @@ def display(obj: Any, fmt: OutputFormat, style: OutputStyle, indent: int = 2) ->
     highlight = style != OutputStyle.NONE
     console = console_factory(no_color=no_color, highlight=highlight)
 
+    if isinstance(obj, str):
+        console.print(_safe(obj))
+        return
+
     if fmt == OutputFormat.JSON:
         console.print_json(data=obj, indent=indent, highlight=highlight)
         return

--- a/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/_requests.py
+++ b/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/_requests.py
@@ -12,10 +12,50 @@ from typing import Any
 from typing import Optional
 
 import requests
+import yaml
 
 from cloudtruth_gen_cli._logging import logger
 
 GET = "GET"
+EXTENSION_MAP = {
+    "application/java-archive": "jar",
+    "application/octet-stream": "bin",
+    "application/pdf": "pdf",
+    "application/xhtml+xml": "xhtml",
+    "application/x-shockwave-flash": "swf",
+    "application/ld+json": "",
+    "application/xml": "xml",
+    "application/zip": "zip",
+    "audio/mpeg": "mpeg",
+    "audio/x-ms-wma": "wma",
+    "audio/vnd.rn-realaudio": "ra",
+    "audio/x-wav": "wav",
+    "image/gif": "gif",
+    "image/jpeg": "jpeg",
+    "image/png": "png",
+    "image/tiff": "tif",
+    "image/vnd.microsoft.icon": "ico",
+    "image/x-icon": "ico",
+    "image/svg+xml": "svg",
+    "text/css": "css",
+    "text/csv": "csv",
+    "text/html": "html",
+    "text/javascript": "js",
+    "text/xml": "xml",
+    "video/mpeg": "mpeg",
+    "video/mp4": "mp4",
+    "video/quicktime": "qt",
+    "video/x-ms-wmv": "wmv",
+    "application/vnd.android.package-archive": "apk",
+    "application/vnd.oasis.opendocument.text": "txt",
+    "application/vnd.ms-excel": "xls",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xls",
+    "application/vnd.ms-powerpoint": "ppt",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation": "xml",
+    "application/msword": "doc",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "doc",
+    "application/vnd.mozilla.xul+xml": "xml",
+}
 
 logger = logger()
 
@@ -128,16 +168,38 @@ def request(
 
     raise_for_error(response)
 
-    # now that we've stopped the clock, let's inspect the body before throwing exceptions
-    result = None
-    if response.content:
+    if not response.content:
+        return None
+
+    encoding = response.encoding or "utf-8"
+    content_type = response.headers.get("Content-type", "application/json")
+    if content_type == "application/json":
         try:
-            result = response.json()
-            # logger.info(f"{method} {pretty_url} body:\n{json.dump(result, indent=2, sort_keys=False)}")
+            return response.json()
         except json.JSONDecodeError:
             logger.error(f"Failed to decode {method} {pretty_url} response")
+            return None
 
-    return result
+    if content_type == "application/yaml":
+        try:
+            content = response.content.decode(encoding=encoding, errors="ignore")
+            return yaml.safe_load(content)
+        except Exception as ex:
+            logger.error(f"Failed to decode {method} {pretty_url} response: {ex}")
+            return None
+
+    if content_type == "text/plain":
+        return response.content.decode(encoding=encoding, errors="ignore")
+
+    extension = EXTENSION_MAP.get(content_type)
+    if extension:
+        filename = f"output.{extension}"
+        with open(filename, "wb") as fp:
+            fp.write(response.content)
+        return f"Wrote content to {filename}"
+
+    logger.error(f"Unhandled content-type={content_type}")
+    return None
 
 
 def depaginate(

--- a/examples/github/github_gen_cli/_display.py
+++ b/examples/github/github_gen_cli/_display.py
@@ -296,6 +296,10 @@ def display(obj: Any, fmt: OutputFormat, style: OutputStyle, indent: int = 2) ->
     highlight = style != OutputStyle.NONE
     console = console_factory(no_color=no_color, highlight=highlight)
 
+    if isinstance(obj, str):
+        console.print(_safe(obj))
+        return
+
     if fmt == OutputFormat.JSON:
         console.print_json(data=obj, indent=indent, highlight=highlight)
         return

--- a/examples/pets-cli/pets_cli/_display.py
+++ b/examples/pets-cli/pets_cli/_display.py
@@ -296,6 +296,10 @@ def display(obj: Any, fmt: OutputFormat, style: OutputStyle, indent: int = 2) ->
     highlight = style != OutputStyle.NONE
     console = console_factory(no_color=no_color, highlight=highlight)
 
+    if isinstance(obj, str):
+        console.print(_safe(obj))
+        return
+
     if fmt == OutputFormat.JSON:
         console.print_json(data=obj, indent=indent, highlight=highlight)
         return

--- a/examples/pets-cli/pets_cli/_requests.py
+++ b/examples/pets-cli/pets_cli/_requests.py
@@ -12,10 +12,50 @@ from typing import Any
 from typing import Optional
 
 import requests
+import yaml
 
 from pets_cli._logging import logger
 
 GET = "GET"
+EXTENSION_MAP = {
+    "application/java-archive": "jar",
+    "application/octet-stream": "bin",
+    "application/pdf": "pdf",
+    "application/xhtml+xml": "xhtml",
+    "application/x-shockwave-flash": "swf",
+    "application/ld+json": "",
+    "application/xml": "xml",
+    "application/zip": "zip",
+    "audio/mpeg": "mpeg",
+    "audio/x-ms-wma": "wma",
+    "audio/vnd.rn-realaudio": "ra",
+    "audio/x-wav": "wav",
+    "image/gif": "gif",
+    "image/jpeg": "jpeg",
+    "image/png": "png",
+    "image/tiff": "tif",
+    "image/vnd.microsoft.icon": "ico",
+    "image/x-icon": "ico",
+    "image/svg+xml": "svg",
+    "text/css": "css",
+    "text/csv": "csv",
+    "text/html": "html",
+    "text/javascript": "js",
+    "text/xml": "xml",
+    "video/mpeg": "mpeg",
+    "video/mp4": "mp4",
+    "video/quicktime": "qt",
+    "video/x-ms-wmv": "wmv",
+    "application/vnd.android.package-archive": "apk",
+    "application/vnd.oasis.opendocument.text": "txt",
+    "application/vnd.ms-excel": "xls",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xls",
+    "application/vnd.ms-powerpoint": "ppt",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation": "xml",
+    "application/msword": "doc",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "doc",
+    "application/vnd.mozilla.xul+xml": "xml",
+}
 
 logger = logger()
 
@@ -128,16 +168,38 @@ def request(
 
     raise_for_error(response)
 
-    # now that we've stopped the clock, let's inspect the body before throwing exceptions
-    result = None
-    if response.content:
+    if not response.content:
+        return None
+
+    encoding = response.encoding or "utf-8"
+    content_type = response.headers.get("Content-type", "application/json")
+    if content_type == "application/json":
         try:
-            result = response.json()
-            # logger.info(f"{method} {pretty_url} body:\n{json.dump(result, indent=2, sort_keys=False)}")
+            return response.json()
         except json.JSONDecodeError:
             logger.error(f"Failed to decode {method} {pretty_url} response")
+            return None
 
-    return result
+    if content_type == "application/yaml":
+        try:
+            content = response.content.decode(encoding=encoding, errors="ignore")
+            return yaml.safe_load(content)
+        except Exception as ex:
+            logger.error(f"Failed to decode {method} {pretty_url} response: {ex}")
+            return None
+
+    if content_type == "text/plain":
+        return response.content.decode(encoding=encoding, errors="ignore")
+
+    extension = EXTENSION_MAP.get(content_type)
+    if extension:
+        filename = f"output.{extension}"
+        with open(filename, "wb") as fp:
+            fp.write(response.content)
+        return f"Wrote content to {filename}"
+
+    logger.error(f"Unhandled content-type={content_type}")
+    return None
 
 
 def depaginate(

--- a/examples/pets-cli/tests/test_display.py
+++ b/examples/pets-cli/tests/test_display.py
@@ -465,6 +465,9 @@ SIMPLE_TABLE = """\
         pytest.param(SIMPLE_DICT, OutputFormat.JSON, json.dumps(SIMPLE_DICT, indent=2), id="json-dict"),
         pytest.param(SIMPLE_DICT, OutputFormat.YAML, yaml.dump(SIMPLE_DICT, indent=2), id="yaml-dict"),
         pytest.param(SIMPLE_DICT, OutputFormat.TABLE, SIMPLE_TABLE, id="table-dict"),
+        pytest.param("My party", OutputFormat.JSON, "My party", id="json-text"),
+        pytest.param("My party", OutputFormat.YAML, "My party", id="yaml-text"),
+        pytest.param("My party", OutputFormat.TABLE, "My party", id="table-text"),
     ]
 )
 def test_display(data, fmt, expected):

--- a/openapi_spec_tools/cli_gen/_display.py
+++ b/openapi_spec_tools/cli_gen/_display.py
@@ -292,6 +292,10 @@ def display(obj: Any, fmt: OutputFormat, style: OutputStyle, indent: int = 2) ->
     highlight = style != OutputStyle.NONE
     console = console_factory(no_color=no_color, highlight=highlight)
 
+    if isinstance(obj, str):
+        console.print(_safe(obj))
+        return
+
     if fmt == OutputFormat.JSON:
         console.print_json(data=obj, indent=indent, highlight=highlight)
         return

--- a/openapi_spec_tools/cli_gen/_requests.py
+++ b/openapi_spec_tools/cli_gen/_requests.py
@@ -8,10 +8,50 @@ from typing import Any
 from typing import Optional
 
 import requests
+import yaml
 
 from openapi_spec_tools.cli_gen._logging import logger
 
 GET = "GET"
+EXTENSION_MAP = {
+    "application/java-archive": "jar",
+    "application/octet-stream": "bin",
+    "application/pdf": "pdf",
+    "application/xhtml+xml": "xhtml",
+    "application/x-shockwave-flash": "swf",
+    "application/ld+json": "",
+    "application/xml": "xml",
+    "application/zip": "zip",
+    "audio/mpeg": "mpeg",
+    "audio/x-ms-wma": "wma",
+    "audio/vnd.rn-realaudio": "ra",
+    "audio/x-wav": "wav",
+    "image/gif": "gif",
+    "image/jpeg": "jpeg",
+    "image/png": "png",
+    "image/tiff": "tif",
+    "image/vnd.microsoft.icon": "ico",
+    "image/x-icon": "ico",
+    "image/svg+xml": "svg",
+    "text/css": "css",
+    "text/csv": "csv",
+    "text/html": "html",
+    "text/javascript": "js",
+    "text/xml": "xml",
+    "video/mpeg": "mpeg",
+    "video/mp4": "mp4",
+    "video/quicktime": "qt",
+    "video/x-ms-wmv": "wmv",
+    "application/vnd.android.package-archive": "apk",
+    "application/vnd.oasis.opendocument.text": "txt",
+    "application/vnd.ms-excel": "xls",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xls",
+    "application/vnd.ms-powerpoint": "ppt",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation": "xml",
+    "application/msword": "doc",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "doc",
+    "application/vnd.mozilla.xul+xml": "xml",
+}
 
 logger = logger()
 
@@ -124,16 +164,38 @@ def request(
 
     raise_for_error(response)
 
-    # now that we've stopped the clock, let's inspect the body before throwing exceptions
-    result = None
-    if response.content:
+    if not response.content:
+        return None
+
+    encoding = response.encoding or "utf-8"
+    content_type = response.headers.get("Content-type", "application/json")
+    if content_type == "application/json":
         try:
-            result = response.json()
-            # logger.info(f"{method} {pretty_url} body:\n{json.dump(result, indent=2, sort_keys=False)}")
+            return response.json()
         except json.JSONDecodeError:
             logger.error(f"Failed to decode {method} {pretty_url} response")
+            return None
 
-    return result
+    if content_type == "application/yaml":
+        try:
+            content = response.content.decode(encoding=encoding, errors="ignore")
+            return yaml.safe_load(content)
+        except Exception as ex:
+            logger.error(f"Failed to decode {method} {pretty_url} response: {ex}")
+            return None
+
+    if content_type == "text/plain":
+        return response.content.decode(encoding=encoding, errors="ignore")
+
+    extension = EXTENSION_MAP.get(content_type)
+    if extension:
+        filename = f"output.{extension}"
+        with open(filename, "wb") as fp:
+            fp.write(response.content)
+        return f"Wrote content to {filename}"
+
+    logger.error(f"Unhandled content-type={content_type}")
+    return None
 
 
 def depaginate(

--- a/tests/cli_gen/test_display.py
+++ b/tests/cli_gen/test_display.py
@@ -461,6 +461,9 @@ SIMPLE_TABLE = """\
         pytest.param(SIMPLE_DICT, OutputFormat.JSON, json.dumps(SIMPLE_DICT, indent=2), id="json-dict"),
         pytest.param(SIMPLE_DICT, OutputFormat.YAML, yaml.dump(SIMPLE_DICT, indent=2), id="yaml-dict"),
         pytest.param(SIMPLE_DICT, OutputFormat.TABLE, SIMPLE_TABLE, id="table-dict"),
+        pytest.param("My party", OutputFormat.JSON, "My party", id="json-text"),
+        pytest.param("My party", OutputFormat.YAML, "My party", id="yaml-text"),
+        pytest.param("My party", OutputFormat.TABLE, "My party", id="table-text"),
     ]
 )
 def test_display(data, fmt, expected):

--- a/tests/cli_gen/test_requests.py
+++ b/tests/cli_gen/test_requests.py
@@ -1,9 +1,12 @@
 import importlib.metadata
 import json
+import os
+from tempfile import TemporaryDirectory
 from typing import Any
 from unittest import mock
 
 import pytest
+import yaml
 from requests import HTTPError
 from requests import Request
 from requests import Response
@@ -15,6 +18,11 @@ from openapi_spec_tools.cli_gen._requests import depaginate
 from openapi_spec_tools.cli_gen._requests import raise_for_error
 from openapi_spec_tools.cli_gen._requests import request
 from openapi_spec_tools.cli_gen._requests import request_headers
+
+APP_JSON = "application/json"
+APP_YAML = "application/yaml"
+TEXT_PLAIN = "text/plain"
+IMAGE_PNG = "image/png"
 
 
 @pytest.mark.parametrize(
@@ -84,11 +92,14 @@ def test_pretty_params(params, expected) -> None:
     assert expected == _pretty_params(params)
 
 
-def convert_body(data: Any) -> Any:
+def convert_body(data: Any, content_type: str) -> Any:
     if data is None:
         return None
     if isinstance(data, (dict, list)):
-        return bytes(json.dumps(data).encode("utf-8"))
+        if content_type == APP_JSON:
+            return bytes(json.dumps(data).encode("utf-8"))
+        if content_type == APP_YAML:
+            return bytes(yaml.dump(data).encode("utf-8"))
     return bytes(data.encode("utf-8"))
 
 
@@ -119,7 +130,7 @@ def test_raise_for_error_errors(status_code, reason, body, expected) -> None:
     response.status_code = status_code
     response.reason = reason
     response.request = Request("GET", "http://dr.com/abc").prepare()
-    response._content = convert_body(body)
+    response._content = convert_body(body, APP_JSON)
 
     with pytest.raises(HTTPError, match=expected):
         raise_for_error(response)
@@ -131,13 +142,14 @@ def success_response(
     status_code: int = 200,
     body: Any = None,
     headers: Any = None,
+    content_type: str = APP_JSON,
 ) -> Response:
     """Convenience method to set some fields."""
     response = Response()
     response.url = url
     response.status_code = status_code
     response.request = Request(method, url).prepare()
-    response._content = convert_body(body)
+    response._content = convert_body(body, content_type)
     if headers:
         response.headers.update(headers)
 
@@ -162,17 +174,25 @@ def test_raise_for_error_success(status_code) -> None:
     raise_for_error(response)
 
 @pytest.mark.parametrize(
-    ["method", "body", "params", "expected"],
+    ["method", "content_type", "body", "params", "expected"],
     [
-        pytest.param("GET", None, {}, None, id="get-no-body"),
-        pytest.param("POST", {}, {}, {}, id="post-empty-body"),
-        pytest.param("PATCH", {"message": "done"}, {}, {"message": "done"}, id="patch-body"),
-        pytest.param("PUT", "plain-text body", {}, None, id="plaintext"),
+        pytest.param("GET", APP_JSON, None, {}, None, id="get-no-body"),
+        pytest.param("POST", APP_JSON, {}, {}, {}, id="post-empty-body"),
+        pytest.param("PATCH", APP_JSON, {"message": "done"}, {}, {"message": "done"}, id="patch-body"),
+        pytest.param("PUT", APP_JSON, "plain-text body", {}, None, id="json-plain"),
+        pytest.param("PUT", TEXT_PLAIN, "plain-text body", {}, "plain-text body", id="text-plain"),
+        pytest.param("PATCH", APP_YAML, {"message": "done"}, {}, {"message": "done"}, id="good-yaml"),
+        pytest.param("PATCH", APP_YAML, "message:\n  other:\n bad:", {}, None, id="bad-yaml"),
+        pytest.param("GET", "text/csv", "a,b,c\n1,2,3\n", {}, "Wrote content to output.csv", id="save-csv"),
+        pytest.param("GET", "application/unknown", "content include, not returned", {}, None, id="unhandled")
     ]
 )
-def test_request(method, body, params, expected):
+def test_request(method, content_type, body, params, expected):
     url = "https://foo/path"
-    response = success_response(url=url, body=body)
+    headers = {"Content-type": content_type}
+    response = success_response(url=url, body=body, headers=headers, content_type=content_type)
+    directory = TemporaryDirectory()
+    os.chdir(directory.name)
 
     prefix = "openapi_spec_tools.cli_gen"
     with (


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Some requests produce different content (e.g. CSV files) that a user should be able to access --  not everything in JSON! 

## CHANGES
<!-- Please explain at a high-level the changes. -->

* Improve the `_display.display()` to support plain text (a `str`).
* Add handling for different content types:
    * `application/json` - same as before
    * `application/yaml` - decode to a list/dict using YAML
    * `text/plain` - decode to text
    * many others - if content type maps to a file extension save the data to the file


<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->