### PR TITLE
Fix issues with class name and non-string enum parameters

### DIFF
--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -401,6 +401,7 @@ if __name__ == "__main__":
             # TODO: uuid
             return "str"
 
+        self.logger.error(f"No Python type found for {schema}/{fmt}")
         return None
 
     def get_parameter_pytype(self, param_data: dict[str, Any]) -> str:
@@ -712,7 +713,7 @@ if __name__ == "__main__":
                 continue
 
             e_name = self.short_reference_name(schema.get(OasField.REFS, "")) or param_data.get(OasField.NAME)
-            e_type = self.schema_to_type(param_data.get(OasField.TYPE), param_data.get(OasField.FORMAT)) or 'str'
+            e_type = self.schema_to_type(schema.get(OasField.TYPE), schema.get(OasField.FORMAT)) or 'str'
             enums[self.class_name(e_name)] = (e_type, values)
 
         for name, prop in body_params.items():

--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -138,24 +138,24 @@ if __name__ == "__main__":
 
         return None
 
+    def _unspecial(self, value: str, replacement: str = '_') -> str:
+        """Replaces the "special" characters with the replacement."""
+        for v in ['/', '*', '.', '-', '@']:
+            value = value.replace(v, replacement)
+        return value
+
     def class_name(self, s: str) -> str:
         """Returns the class name for provided string"""
-        value = to_camel_case(s.replace('.', '_'))
+        value = to_camel_case(self._unspecial(s))
         return value[0].upper() + value[1:]
 
     def function_name(self, s: str) -> str:
         """Returns the function name for the provided string"""
-        value = to_snake_case(s)
-        for v in ['/', '*', '.', '-', '@']:
-            value = value.replace(v, '_')
-        return value
+        return to_snake_case(self._unspecial(s))
 
     def variable_name(self, s: str) -> str:
         """Returns the variable name for the provided string"""
-        value = to_snake_case(s)
-        for v in ['/', '*', '.', '-', '@']:
-            value = value.replace(v, '_')
-        return value
+        return to_snake_case(self._unspecial(s))
 
     def option_name(self, s: str) -> str:
         """Returns the typer option name for the provided string."""

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -447,6 +447,13 @@ class Simple(str, Enum):  # noqa: F811
 """
 
 FOOBAR_ENUM = SIMPLE_ENUM.replace("Simple", "FooBar")
+NUMBER_ENUM = """\
+class SimpleNumber(int, Enum):  # noqa: F811
+    VALUE_12 = 12
+    VALUE_37 = 37
+    VALUE_11 = 11
+
+"""
 
 NON_STR_ENUM = """\
 class anyThing_goes(int, Enum):  # noqa: F811
@@ -464,6 +471,7 @@ SIMPLE_PARAM = {
 }
 
 FOOBAR_PARAM = {SCHEMA: {TYPE: "string", ENUM: ["aOrB", "b_or_C"]}, "name": "fooBar"}
+NUMBER_PARAM = {SCHEMA: {TYPE: "integer", ENUM: [12, 37, 11]}, "name": "simple-number"}
 
 @pytest.mark.parametrize(
     ["name", "enum_type", "values", "expected"],
@@ -495,6 +503,13 @@ def test_enum_declaration(name, enum_type, values, expected):
             {},
             f"\n{SIMPLE_ENUM}",
             id="ref-query",
+        ),
+        pytest.param(
+            [NUMBER_PARAM],
+            [],
+            {},
+            f"\n{NUMBER_ENUM}",
+            id="number",
         ),
         pytest.param(
             [],
@@ -544,7 +559,7 @@ def test_enum_declaration(name, enum_type, values, expected):
             {"fooBar": {TYPE: "string", ENUM: ["aOrB", "b_or_C"]}},
             f"\n{SIMPLE_ENUM}\n{FOOBAR_ENUM}",
             id="multiple",
-        )
+        ),
     ],
 )
 def test_enum_definitions(path_params, query_params, body_params, expected):

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -206,6 +206,7 @@ def test_schema_to_type(schema, fmt, expected):
         pytest.param("camelCaseValue", "CamelCaseValue", id="camel"),
         pytest.param("decimal.dot.value", "DecimalDotValue", id="dotted"),
         pytest.param("AlreadyClassName", "AlreadyClassName", id="class"),
+        pytest.param("dash-or-bash", "DashOrBash", id="dash"),
     ]
 )
 def test_class_name(proposed, expected):
@@ -221,6 +222,7 @@ def test_class_name(proposed, expected):
         pytest.param("camelCaseValue", "camel_case_value", id="camel"),
         pytest.param("decimal.dot.value", "decimal_dot_value", id="dotted"),
         pytest.param("users/list", "users_list", id="slash"),
+        pytest.param("dash-or-bash", "dash_or_bash", id="dash"),
     ],
 )
 def test_function_name(proposed, expected):


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Fixed a couple small issues.
1. `Generator.class_name()` was mishandling dashes. Previously, would let `class-name` would become `Class-name` (and it should be `ClassName`).
2. Added `logger.error()` to `Generator.schema_to_type()` and discovered that parameter inputs should be coming from the `schema` instead of the property data.


## CHANGES
<!-- Please explain at a high-level the changes. -->

1. Added `Generator._unspecial()` to consolidate logic for replacing "special" characters with `_`, and use the new function inside the `class_name()`.
2. Pull `schema_to_type()` inputs from parameter `schema` instead of property data.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->