### PR TITLE
Fix a couple CLI generator issues

### DIFF
--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -690,7 +690,7 @@ if __name__ == "__main__":
         """Turns data into an enum declation"""
         prefix = "" if enum_type == "str" else "VALUE_"
         declarations = [
-            f"{prefix}{to_snake_case(str(v)).upper()} = {maybe_quoted(v)}"
+            f"{prefix}{self.variable_name(str(v)).upper()} = {maybe_quoted(v)}"
             for v in values
         ]
         # NOTE: the noqa is due to potentially same definition ahead of multiple functions

--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -391,7 +391,7 @@ if __name__ == "__main__":
             return "bool"
         if schema == "integer":
             return "int"
-        if schema == "numeric":
+        if schema in ("numeric", "number"):
             return "float"
         if schema == "string":
             if fmt == "date-time":

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -183,6 +183,7 @@ def test_op_param_formation():
         pytest.param("boolean", None, "bool", id="boolean"),
         pytest.param("integer", None, "int", id="integer"),
         pytest.param("numeric", None, "float", id="numeric"),
+        pytest.param("number", None, "float", id="number"),
         pytest.param("string", None, "str", id="str"),
         pytest.param("string", "date-time", "datetime", id="datetime"),
         pytest.param("string", "date", "date", id="date"),

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -444,6 +444,7 @@ SIMPLE_ENUM = """\
 class Simple(str, Enum):  # noqa: F811
     A_OR_B = "aOrB"
     B_OR_C = "b_or_C"
+    _MINUS = "-minus"
 
 """
 
@@ -466,18 +467,18 @@ class anyThing_goes(int, Enum):  # noqa: F811
 
 SIMPLE_PARAM = {
     SCHEMA: {
-        TYPE: "string", ENUM: ["aOrB", "b_or_C"], "$ref": "#/components/schemas/Simple"
+        TYPE: "string", ENUM: ["aOrB", "b_or_C", "-minus"], "$ref": "#/components/schemas/Simple"
     },
     "name": "fooBar",
 }
 
-FOOBAR_PARAM = {SCHEMA: {TYPE: "string", ENUM: ["aOrB", "b_or_C"]}, "name": "fooBar"}
+FOOBAR_PARAM = {SCHEMA: {TYPE: "string", ENUM: ["aOrB", "b_or_C", "-minus"]}, "name": "fooBar"}
 NUMBER_PARAM = {SCHEMA: {TYPE: "integer", ENUM: [12, 37, 11]}, "name": "simple-number"}
 
 @pytest.mark.parametrize(
     ["name", "enum_type", "values", "expected"],
     [
-        pytest.param("Simple", "str", ["aOrB", "b_or_C"], SIMPLE_ENUM, id="str"),
+        pytest.param("Simple", "str", ["aOrB", "b_or_C", "-minus"], SIMPLE_ENUM, id="str"),
         pytest.param("anyThing_goes", "int", [1, None, True], NON_STR_ENUM, id="non-str"),
     ]
 )
@@ -515,7 +516,7 @@ def test_enum_declaration(name, enum_type, values, expected):
         pytest.param(
             [],
             [],
-            {"fooBar": {TYPE: "string", ENUM: ["aOrB", "b_or_C"], "x-reference": "Simple"}},
+            {"fooBar": {TYPE: "string", ENUM: ["aOrB", "b_or_C", "-minus"], "x-reference": "Simple"}},
             f"\n{SIMPLE_ENUM}",
             id="ref-body",
         ),
@@ -536,28 +537,28 @@ def test_enum_declaration(name, enum_type, values, expected):
         pytest.param(
             [],
             [],
-            {"fooBar": {TYPE: "string", ENUM: ["aOrB", "b_or_C"]}},
+            {"fooBar": {TYPE: "string", ENUM: ["aOrB", "b_or_C", "-minus"]}},
             f"\n{FOOBAR_ENUM}",
             id="unref-body",
         ),
         pytest.param(
             [],
             [],
-            {"foo.bar": {TYPE: "string", ENUM: ["aOrB", "b_or_C"]}},
+            {"foo.bar": {TYPE: "string", ENUM: ["aOrB", "b_or_C", "-minus"]}},
             f"\n{FOOBAR_ENUM}",
             id="subprop-body",
         ),
         pytest.param(
             [SIMPLE_PARAM],
             [SIMPLE_PARAM],
-            {"fooBar": {TYPE: "string", ENUM: ["aOrB", "b_or_C"], "x-reference": "Simple"}},
+            {"fooBar": {TYPE: "string", ENUM: ["aOrB", "b_or_C", "-minus"], "x-reference": "Simple"}},
             f"\n{SIMPLE_ENUM}",
             id="de-dup",
         ),
         pytest.param(
             [SIMPLE_PARAM],
             [FOOBAR_PARAM],
-            {"fooBar": {TYPE: "string", ENUM: ["aOrB", "b_or_C"]}},
+            {"fooBar": {TYPE: "string", ENUM: ["aOrB", "b_or_C", "-minus"]}},
             f"\n{SIMPLE_ENUM}\n{FOOBAR_ENUM}",
             id="multiple",
         ),


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Fixes to allow generating clean code.

## CHANGES
<!-- Please explain at a high-level the changes. -->

1. Equate OAS `type: number` to a Python `float`
2. Enum value naming needed special characters removed/replaced.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->