### PR TITLE
Support more complex parameter types

### DIFF
--- a/tests/assets/misc.yaml
+++ b/tests/assets/misc.yaml
@@ -97,6 +97,12 @@ paths:
             - Mon
             - Tue
             - Wed
+        - name: strListProp
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Support more complex parameter types. Still need to work on references.

## CHANGES
<!-- Please explain at a high-level the changes. -->

Pre-process query parameters into properties where we condense `oneOf` fields if possible, and choose `anyOf`.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->