### PR TITLE
Fix issue with enum parameters with a default value

### DIFF
--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -528,10 +528,7 @@ if __name__ == "__main__":
                 arg_default = " = None"
                 typer_args.append('show_default=False')
             else:
-                if arg_type in ("str", "datetime"):
-                    arg_default = f' = "{schema_default}"'
-                else:
-                    arg_default = f" = {schema_default}"
+                arg_default = f" = {maybe_quoted(schema_default)}"
         is_enum = bool(schema.get(OasField.ENUM))
         if is_enum:
             typer_args.append("case_sensitive=False")

--- a/tests/assets/misc.yaml
+++ b/tests/assets/misc.yaml
@@ -103,6 +103,15 @@ paths:
             type: array
             items:
               type: string
+        - name: enumWithDefault
+          in: query
+          schema:
+            type: str
+            enum:
+            - This
+            - That
+            - TheOtherThing
+            default: TheOtherThing
       requestBody:
         content:
           application/json:

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -176,7 +176,9 @@ def test_op_param_formation():
         _l.logger().warning("--day-value was deprecated in last-release")
         params["dayValue"] = day_value
     if str_list_prop is not None:
-        params["strListProp"] = str_list_prop\
+        params["strListProp"] = str_list_prop
+    if enum_with_default is not None:
+        params["enumWithDefault"] = enum_with_default\
 """
     text = uut.op_param_formation(query_params)
     assert expected == text
@@ -438,6 +440,10 @@ def test_op_query_arguments():
     )
     assert (
         'str_list_prop: Annotated[Optional[list[str]], typer.Option(show_default=False, help="")] = None'
+        in text
+    )
+    assert (
+        'enum_with_default: Annotated[EnumWithDefault, typer.Option(case_sensitive=False, help="")] = "TheOtherThing"'
         in text
     )
 


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

The default value of an enum parameter was not getting correctly quoted.

With the fix, the parameter declaration looks like:
```Python
enum_with_default: Annotated[EnumWithDefault, typer.Option(case_sensitive=False, help="")] = "TheOtherThing"
```

Without the fix, the parameter declarations that looked like:
```Python
enum_with_default: Annotated[EnumWithDefault, typer.Option(case_sensitive=False, help="")] = TheOtherThing
```

## CHANGES
<!-- Please explain at a high-level the changes. -->

Use the `maybe_quoted()` utility to determine if the parameter default value should be quoted -- it decides by inspecting the type.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->