### PR TITLE
Treat space in names just like any other special character

### DIFF
--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -145,7 +145,7 @@ if __name__ == "__main__":
 
     def _unspecial(self, value: str, replacement: str = '_') -> str:
         """Replaces the "special" characters with the replacement."""
-        for v in ['/', '*', '.', '-', '@']:
+        for v in ['/', '*', '.', '-', '@', ' ']:
             value = value.replace(v, replacement)
         return value
 

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -215,6 +215,7 @@ def test_schema_to_type(schema, fmt, expected):
         pytest.param("decimal.dot.value", "DecimalDotValue", id="dotted"),
         pytest.param("AlreadyClassName", "AlreadyClassName", id="class"),
         pytest.param("dash-or-bash", "DashOrBash", id="dash"),
+        pytest.param("space included", "SpaceIncluded", id="space"),
     ]
 )
 def test_class_name(proposed, expected):
@@ -231,6 +232,7 @@ def test_class_name(proposed, expected):
         pytest.param("decimal.dot.value", "decimal_dot_value", id="dotted"),
         pytest.param("users/list", "users_list", id="slash"),
         pytest.param("dash-or-bash", "dash_or_bash", id="dash"),
+        pytest.param("space included", "space_included", id="space"),
     ],
 )
 def test_function_name(proposed, expected):
@@ -247,6 +249,7 @@ def test_function_name(proposed, expected):
         pytest.param("decimal.dot.value", "decimal_dot_value", id="dotted"),
         pytest.param("users/list", "users_list", id="slash"),
         pytest.param("page-name", "page_name", id="dash"),
+        pytest.param("space included", "space_included", id="space"),
     ],
 )
 def test_variable_name(proposed, expected):
@@ -263,6 +266,7 @@ def test_variable_name(proposed, expected):
         pytest.param("decimal.dot.value", "--decimal-dot-value", id="dotted"),
         pytest.param("users/list", "--users-list", id="slash"),
         pytest.param("page-name", "--page-name", id="dash"),
+        pytest.param("space included", "--space-included", id="space"),
     ],
 )
 def test_option_name(proposed, expected):


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

In some cases (e.g. enum values), the desired variable name may contain a space. Treat the space just like any other special character, and replace it with the underscore.


## CHANGES
<!-- Please explain at a high-level the changes. -->

Add the space character to the list of special characters to replace.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->