### PR TITLE
Fix issue with default visibility for body arguments

### DIFF
--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -639,8 +639,8 @@ if __name__ == "__main__":
                 py_type = 'Any'
 
             t_args = {}
-            def_val = maybe_quoted(prop_data.get(OasField.DEFAULT))
-            if def_val is not None:
+            def_val = prop_data.get(OasField.DEFAULT)
+            if def_val is None:
                 t_args["show_default"] = False
             is_enum = bool(prop_data.get(OasField.ENUM))
             if is_enum:
@@ -653,7 +653,7 @@ if __name__ == "__main__":
             if help:
                 t_args['help'] = f'"{simple_escape(help)}"'
             t_decl = f"typer.Option({', '.join([f'{k}={v}' for k, v in t_args.items()])})"
-            arg = f"{self.variable_name(prop_name)}: Annotated[{py_type}, {t_decl}] = {def_val}"
+            arg = f"{self.variable_name(prop_name)}: Annotated[{py_type}, {t_decl}] = {maybe_quoted(def_val)}"
             args.append(arg)
 
         return args

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -940,7 +940,7 @@ def test_op_body_arguments():
     assert 'name: Annotated[str, typer.Option(show_default=False, help="Pet name")] = None' in text
     assert 'tag: Annotated[Optional[str], typer.Option(show_default=False, help="Pet classification")] = None' in text
     assert (
-        'another_value: Annotated[Optional[str], typer.Option(show_default=False, hidden=True, '
+        'another_value: Annotated[Optional[str], typer.Option(hidden=True, '
         'help="A string with a default")] = "Anything goes"'
         in text
     )


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Fix issue where default body property values were not shown. 

## CHANGES
<!-- Please explain at a high-level the changes. -->

Fixed logic and call the `maybe_quoted()` later to insure there's a clear view of the default value.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->