### PR TITLE
Fixes for string enum's with non-string values/defaults

### DIFF
--- a/tests/assets/misc.yaml
+++ b/tests/assets/misc.yaml
@@ -112,6 +112,16 @@ paths:
             - That
             - TheOtherThing
             default: TheOtherThing
+        - name: strEnumWithIntValues
+          in: query
+          schema:
+            type: string
+            enum:
+            - 1
+            - two
+            - 3
+            - four
+            default: 1
       requestBody:
         content:
           application/json:
@@ -206,6 +216,15 @@ components:
             x-deprecated: 7.8.9
           flavor:
             $ref: "#/components/schemas/Species"
+          binString:
+            type: string
+            enum:
+            - 1
+            - 2
+            - 4
+            - 8
+            default: 4
+
     Pets:
       type: array
       maxItems: 100

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -178,7 +178,9 @@ def test_op_param_formation():
     if str_list_prop is not None:
         params["strListProp"] = str_list_prop
     if enum_with_default is not None:
-        params["enumWithDefault"] = enum_with_default\
+        params["enumWithDefault"] = enum_with_default
+    if str_enum_with_int_values is not None:
+        params["strEnumWithIntValues"] = str_enum_with_int_values\
 """
     text = uut.op_param_formation(query_params)
     assert expected == text
@@ -450,6 +452,10 @@ def test_op_query_arguments():
         'enum_with_default: Annotated[EnumWithDefault, typer.Option(case_sensitive=False, help="")] = "TheOtherThing"'
         in text
     )
+    assert (
+        'str_enum_with_int_values: Annotated[StrEnumWithIntValues, typer.Option(case_sensitive=False, help="")] = "1"'
+        in text
+    )
 
     # make sure path params not included
     assert 'num_feet: Annotated' not in text
@@ -499,6 +505,18 @@ class anyThing_goes(int, Enum):  # noqa: F811
     VALUE_TRUE = True
 
 """
+MIXED_ENUM = """\
+class MixedValues(str, Enum):  # noqa: F811
+    VALUE_A = "a"
+    VALUE_1 = "1"
+    VALUE_TRUE = "True"
+    VALUE_B = "b"
+"""
+INT_STR_ENUM = """\
+class IntStrings(str, Enum):  # noqa: F811
+    VALUE_10 = "10"
+    VALUE_10_1 = "10.1"
+"""
 
 SIMPLE_PARAM = {
     SCHEMA: {
@@ -509,6 +527,8 @@ SIMPLE_PARAM = {
 
 FOOBAR_PARAM = {SCHEMA: {TYPE: "string", ENUM: ["aOrB", "b_or_C", "-minus"]}, "name": "fooBar"}
 NUMBER_PARAM = {SCHEMA: {TYPE: "integer", ENUM: [12, 37, 11]}, "name": "simple-number"}
+MIXED_PARAM = {SCHEMA: {TYPE: "string", ENUM: ["a", 1, True, "b"]}, "name": "mixed-values"}
+INT_STR_PARAM = {SCHEMA: {TYPE: "string", ENUM: ["10", "10.1"]}, "name": "int-strings"}
 
 @pytest.mark.parametrize(
     ["name", "enum_type", "values", "expected"],
@@ -597,6 +617,20 @@ def test_enum_declaration(name, enum_type, values, expected):
             f"\n{SIMPLE_ENUM}\n{FOOBAR_ENUM}",
             id="multiple",
         ),
+        pytest.param(
+            [],
+            [MIXED_PARAM],
+            {},
+            f"\n{MIXED_ENUM}\n",
+            id="mixed",
+        ),
+        pytest.param(
+            [],
+            [INT_STR_PARAM],
+            {},
+            f"\n{INT_STR_ENUM}\n",
+            id="int-str"
+        )
     ],
 )
 def test_enum_definitions(path_params, query_params, body_params, expected):
@@ -952,6 +986,10 @@ def test_op_body_arguments():
     assert (
         'flavor: Annotated[Optional[Species], '
         'typer.Option(show_default=False, case_sensitive=False, help="Species type")] = None'
+        in text
+    )
+    assert (
+        'bin_string: Annotated[Optional[BinString], typer.Option(case_sensitive=False)] = "4"'
         in text
     )
 


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Fix an issue with enumerations where the type is string, but the values are not strings (or string representations of numbers).

Here's a set of YAML to illustrate:
```YAML
binValue:
  type: string
  enum:
  - 1
  - 2
  - 4
  - 8
```

Previously, this yielded a bad Python enumeration definition along the lines of:
```Python
class BinValue(str, Enum):
    1 = "1"
    2 = "2"
    4 = "4"
    8 = "8"
```
This is invalid because the enumeration value names are not legitimate.

With these changes, you will see something like:
```Python
class BinValue(str, Enum):
    VALUE_1 = "1"
    VALUE_2 = "2"
    VALUE_4 = "4"
    VALUE_8 = "8"
```

## CHANGES
<!-- Please explain at a high-level the changes. -->

Update the enumeration definition to better determine legitimate enumeration value names.
Update the enumeration default values to deal with string defaults always being quoted.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->