### PR TITLE
Fix issue when oneOf items do not have a type

### DIFF
--- a/openapi_spec_tools/utils.py
+++ b/openapi_spec_tools/utils.py
@@ -409,7 +409,7 @@ def _is_nullable(prop_data: dict[str, Any]) -> bool:
     # iterate through all the options in anyOf/oneOf
     for tag in [OasField.ANY_OF, OasField.ONE_OF]:
         for item in prop_data.get(tag, []):
-            if _includes_null(item.get(OasField.TYPE)):
+            if _includes_null(item.get(OasField.TYPE, [])):
                 return True
 
     return False

--- a/tests/assets/oas31.yaml
+++ b/tests/assets/oas31.yaml
@@ -53,6 +53,7 @@ components:
         - consumers
         - websites
         - anotherProp
+        - untypedProp
       properties:
         id:
           type: integer
@@ -71,6 +72,10 @@ components:
               format: 'uri'
               maxLength: 255
             - type: 'null'
+        untypedProp:
+          oneOf:
+          - $ref: "#/components/schemas/Service"
+          - $ref: "#/components/schemas/Error"
         anotherProp:
           description: property with list of types, but nothing null
           type:


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

When a `oneOf` list item did not have a `type` property (such as below), the search to determine if the item was nullable was crashing.

```YAML
  untypedProp:
    oneOf:
    - $ref: "#/components/schemas/Service"
    - $ref: "#/components/schemas/Error"
```

## CHANGES
<!-- Please explain at a high-level the changes. -->

Provide a default value (empty list) for `type` when iterating through `oneOf` components.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->