### PR TITLE
Allow for oneOf parameters in the request body

### DIFF
--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -649,7 +649,6 @@ if __name__ == "__main__":
         for prop_name, prop_data in body_params.items():
             py_type = self.get_property_pytype(prop_name, prop_data)
             if not py_type:
-                # breakpoint()
                 # log an error and use 'Any'
                 self.logger.error(f"Unable to determine Python type for {prop_name}={prop_data}")
                 py_type = 'Any'

--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -289,6 +289,18 @@ if __name__ == "__main__":
             if prop_data.get(OasField.READ_ONLY, False):
                 continue
 
+            one_of = prop_data.get(OasField.ONE_OF)
+            if one_of:
+                prop_data = deepcopy(prop_data)
+                prop_data.pop(OasField.ONE_OF)
+                updated = self.condense_one_of(one_of)
+                if len(updated) == 1:
+                    prop_data.update(updated[0])
+                else:
+                    # just grab the first one... not sure this is the best choice, but need to do something
+                    self.logger.warning(f"Grabbing oneOf[0] item from body {updated}")
+                    prop_data.update(updated[0])
+
             reference = self.prop_find_reference(prop_data)
             short_refname = self.short_reference_name(reference)
             if not reference:
@@ -637,6 +649,7 @@ if __name__ == "__main__":
         for prop_name, prop_data in body_params.items():
             py_type = self.get_property_pytype(prop_name, prop_data)
             if not py_type:
+                # breakpoint()
                 # log an error and use 'Any'
                 self.logger.error(f"Unable to determine Python type for {prop_name}={prop_data}")
                 py_type = 'Any'

--- a/tests/assets/misc.yaml
+++ b/tests/assets/misc.yaml
@@ -224,6 +224,19 @@ components:
             - 4
             - 8
             default: 4
+          optionalList:
+            oneOf:
+            - type: string
+            - type: array
+              items:
+                type: string
+          firstChoice:
+            oneOf:
+            - type: integer
+            - type: array
+              items:
+                type: string
+          
 
     Pets:
       type: array

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -386,6 +386,10 @@ def test_op_body_formation():
     assert 'if bogus is not None:' in text
     assert '_l.logger().warning("--bogus was deprecated in 7.8.9 and should not be used")' in text
     assert 'body["bogus"] = bogus' in text
+    assert 'if optional_list is not None:' in text
+    assert 'body["optionalList"] = optional_list' in text
+    assert 'if first_choice is not None:' in text
+    assert 'body["firstChoice"] = first_choice' in text
 
 
 def test_op_path_arguments():
@@ -994,6 +998,14 @@ def test_op_body_arguments():
     )
     assert (
         'bin_string: Annotated[Optional[BinString], typer.Option(case_sensitive=False)] = "4"'
+        in text
+    )
+    assert(
+        'optional_list: Annotated[Optional[list[str]], typer.Option(show_default=False)] = None'
+        in text
+    )
+    assert(
+        'first_choice: Annotated[Optional[int], typer.Option(show_default=False)] = None'
         in text
     )
 


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Want to handle parameters in the request body that use the `oneOf` property.

## CHANGES
<!-- Please explain at a high-level the changes. -->

Use same pattern (and function) as the path parameters to condense the `oneOf` values. 


<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->