### PR TITLE
Allow for list items to have a oneOf type

### DIFF
--- a/tests/assets/misc.yaml
+++ b/tests/assets/misc.yaml
@@ -236,7 +236,13 @@ components:
             - type: array
               items:
                 type: string
-          
+          listVarious:
+            type: array
+            items:
+              oneOf:
+              - type: boolean
+              - type: integer
+              - type: string
 
     Pets:
       type: array

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -390,6 +390,8 @@ def test_op_body_formation():
     assert 'body["optionalList"] = optional_list' in text
     assert 'if first_choice is not None:' in text
     assert 'body["firstChoice"] = first_choice' in text
+    assert 'if list_various is not None:' in text
+    assert 'body["listVarious"] = list_various' in text
 
 
 def test_op_path_arguments():
@@ -1006,6 +1008,10 @@ def test_op_body_arguments():
     )
     assert(
         'first_choice: Annotated[Optional[int], typer.Option(show_default=False)] = None'
+        in text
+    )
+    assert (
+        'list_various: Annotated[Optional[list[bool]], typer.Option(show_default=False)] = None'
         in text
     )
 


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Body properties can be an array whose items are defined by a `oneOf`, such as:

```YAML
    users:
      type: array
      items:
        oneOf:
        - $ref: "#/components/schemas/UserId"
        - $ref: "#/components/schemas/UserName"
```

## CHANGES
<!-- Please explain at a high-level the changes. -->

Update `get_items_model()` to handle `oneOf` properties. Currently uses simplistic choosing of the first item.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->