### PR TITLE
Consider parenthesis, brackets, and braces special characters for naming

### DIFF
--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -30,6 +30,7 @@ SHEBANG = """\
 COLLECTIONS = {
     "array": "list",
 }
+SPECIAL_CHARS = ['/', '*', '.', '-', '@', ' ', '%', '<', '>', ':', ';', '(', ')', '{', '}', '[', ']']
 
 
 class Generator:
@@ -145,7 +146,7 @@ if __name__ == "__main__":
 
     def _unspecial(self, value: str, replacement: str = '_') -> str:
         """Replaces the "special" characters with the replacement."""
-        for v in ['/', '*', '.', '-', '@', ' ', '%', '<', '>', ':', ';']:
+        for v in SPECIAL_CHARS:
             value = value.replace(v, replacement)
         return value
 

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -219,6 +219,11 @@ def test_schema_to_type(schema, fmt, expected):
         pytest.param("dash-or-bash", "DashOrBash", id="dash"),
         pytest.param("space included", "SpaceIncluded", id="space"),
         pytest.param("more%special<chars:that>cause;problems", "MoreSpecialCharsThatCauseProblems", id="more"),
+        pytest.param(
+            "some{brace}and[bracket]and(paren)testing",
+            "SomeBraceAndBracketAndParenTesting",
+            id="parens",
+        ),
     ]
 )
 def test_class_name(proposed, expected):
@@ -237,6 +242,11 @@ def test_class_name(proposed, expected):
         pytest.param("dash-or-bash", "dash_or_bash", id="dash"),
         pytest.param("space included", "space_included", id="space"),
         pytest.param("more%special<chars:that>cause;problems", "more_special_chars_that_cause_problems", id="more"),
+        pytest.param(
+            "some{brace}and[bracket]and(paren)testing",
+            "some_brace_and_bracket_and_paren_testing",
+            id="parens",
+        ),
     ],
 )
 def test_function_name(proposed, expected):
@@ -255,6 +265,11 @@ def test_function_name(proposed, expected):
         pytest.param("page-name", "page_name", id="dash"),
         pytest.param("space included", "space_included", id="space"),
         pytest.param("more%special<chars:that>cause;problems", "more_special_chars_that_cause_problems", id="more"),
+        pytest.param(
+            "some{brace}and[bracket]and(paren)testing",
+            "some_brace_and_bracket_and_paren_testing",
+            id="parens",
+        ),
     ],
 )
 def test_variable_name(proposed, expected):
@@ -273,6 +288,11 @@ def test_variable_name(proposed, expected):
         pytest.param("page-name", "--page-name", id="dash"),
         pytest.param("space included", "--space-included", id="space"),
         pytest.param("more%special<chars:that>cause;problems", "--more-special-chars-that-cause-problems", id="more"),
+        pytest.param(
+            "some{brace}and[bracket]and(paren)testing",
+            "--some-brace-and-bracket-and-paren-testing",
+            id="parens",
+        ),
     ],
 )
 def test_option_name(proposed, expected):


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Some names include parenthesis, braces, or brackets. This is most apparent when creating enum names with string values.


## CHANGES
<!-- Please explain at a high-level the changes. -->

Replace special characters like the others.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->