### PR TITLE
Only include a body when there are body parameters

### DIFF
--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -891,7 +891,7 @@ if __name__ == "__main__":
             "headers=headers",
             "params=params",
         ])
-        if self.op_get_content_type(op):
+        if body_params:
             req_args.append("body=body")
         req_args.append("timemout=_api_timeout")
 

--- a/tests/assets/misc.yaml
+++ b/tests/assets/misc.yaml
@@ -175,6 +175,14 @@ paths:
       responses:
         '204':
           description: This is an empty response
+    post:
+      operationId: snaFooCreate
+      summary: Create a normally messed up situation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ComplexList'
 components:
   parameters:
     PageSize:
@@ -576,3 +584,10 @@ components:
           oneOf:
           - $ref: '#/components/schemas/RoleEnum'
           description: The role that the user has in the organization.
+    ComplexList:
+      type: object
+      properties:
+        attachments:
+          type: array
+          items:
+            $ref: "#/components/schemas/Attachment"


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Fix issue where a body would be included in the request even if no body parameters were found. This can happen when items in the body schema are "not settable". For example, a list of complex data objects is not currently anything that can be expressed in the generated code.

## CHANGES
<!-- Please explain at a high-level the changes. -->

Only include body if settable body parameters are found -- not just if a body is specified.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->