### PR TITLE
Simplify schema type when it is a list

### DIFF
--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -443,7 +443,11 @@ if __name__ == "__main__":
             reduced = set(schema) - NULL_TYPES
             if len(reduced) == 1:
                 return reduced.pop()
-            return schema
+            # loop through to find the items from the ordered schema
+            for item in schema:
+                if item in reduced:
+                    self.logger.debug(f"Choosing {item} type from {', '.join(schema)}")
+                    return item
 
         self.logger.warning(f"Unable to simplify type for {schema}")
         return None

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -306,8 +306,8 @@ def test_option_name(proposed, expected):
         pytest.param(None, None, id="none"),
         pytest.param("foo", "foo", id="str"),
         pytest.param({"sna": "foo"}, {"sna": "foo"}, id="dict"),
-        pytest.param(["sna", "foo"], ["sna", "foo"], id="list-unmod"),
-        pytest.param(["null", "sna"], "sna", id="list-mod"),
+        pytest.param(["sna", "foo"], "sna", id="list-no-null"),
+        pytest.param(["null", "sna"], "sna", id="list-null"),
         pytest.param(1, None, id="error"),
     ]
 )


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

When the schema type is a simple list, choose the first one. Previously, we were not finding the Python type and defaulting to `str`.

## CHANGES
<!-- Please explain at a high-level the changes. -->

When simplifying the type, choose the first "non-null" item in the schema type list.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->