### PR TITLE
Update the default cli-gen log level to info

### DIFF
--- a/openapi_spec_tools/cli_gen/cli.py
+++ b/openapi_spec_tools/cli_gen/cli.py
@@ -289,7 +289,7 @@ def generate_cli(
     ] = None,
     include_tests: Annotated[bool, typer.Option("--tests/--no-tests", help="Include tests in generated coode")] = True,
     start: StartPointOption = DEFAULT_START,
-    log_level: LogLevelOption = "DEBUG",
+    log_level: LogLevelOption = "info",
 ) -> None:
     """
     Generates CLI code based on the provided parameters.


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Go from debug to info level as the default to reduce the noise.

## CHANGES
<!-- Please explain at a high-level the changes. -->

Update the default level.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->