### PR TITLE
Fixes for names conflicting with builtins

### DIFF
--- a/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/users.py
+++ b/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/users.py
@@ -114,7 +114,7 @@ def users_list(
     ordering: Annotated[Optional[str], typer.Option(show_default=False, help="Which field to use when ordering the results.")] = None,
     page: Annotated[Optional[int], typer.Option(show_default=False, help="A page number within the paginated result set.")] = None,
     page_size: Annotated[Optional[int], typer.Option(show_default=False, help="Number of results to return per page.")] = None,
-    type: Annotated[Optional[str], typer.Option(show_default=False, help="")] = None,
+    type_: Annotated[Optional[str], typer.Option("--type", show_default=False, help="")] = None,
     _api_host: _a.ApiHostOption = "",
     _api_key: _a.ApiKeyOption = None,
     _api_timeout: _a.ApiTimeoutOption = 5,
@@ -141,8 +141,8 @@ def users_list(
         params["page"] = page
     if page_size is not None:
         params["page_size"] = page_size
-    if type is not None:
-        params["type"] = type
+    if type_ is not None:
+        params["type"] = type_
 
     try:
         data = _r.depaginate(page_info, url, headers=headers, params=params, timemout=_api_timeout)

--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -35,7 +35,7 @@ SPECIAL_CHARS = ['/', '*', '.', '-', '@', ' ', '%', '<', '>', ':', ';', '(', ')'
 
 # This is an incomplete list of Python builtins that should avoided in variable names
 NAME_CONFLICTS = {"all", "any", "bool", "class", "dict", "float", "input", "int", "list", "type"}
-CONFLICT_PREFIX = "gen_"
+CONFLICT_SUFFIX = "_"
 
 
 class Generator:
@@ -181,7 +181,7 @@ if __name__ == "__main__":
         """Get the function name for the provided string."""
         vname = to_snake_case(self._unspecial(s))
         if vname in NAME_CONFLICTS:
-            return f"{CONFLICT_PREFIX}{vname}"
+            return f"{vname}{CONFLICT_SUFFIX}"
 
         return vname
 
@@ -189,7 +189,7 @@ if __name__ == "__main__":
         """Get the variable name for the provided string."""
         vname = to_snake_case(self._unspecial(s))
         if vname in NAME_CONFLICTS:
-            return f"{CONFLICT_PREFIX}{vname}"
+            return f"{vname}{CONFLICT_SUFFIX}"
 
         return vname
 

--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -38,10 +38,13 @@ RESERVED = {
     "all",
     "any",
     "bool",
+    "breakpoint",
     "class",
+    "continue",
     "dict",
     "except",
     "float",
+    "for",
     "format",
     "in",
     "input",
@@ -49,7 +52,11 @@ RESERVED = {
     "list",
     "max",
     "min",
+    "print",
+    "set",
     "type",
+    "try",
+    "while",
 }
 CONFLICT_SUFFIX = "_"
 

--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -34,7 +34,23 @@ COLLECTIONS = {
 SPECIAL_CHARS = ['/', '*', '.', '-', '@', ' ', '%', '<', '>', ':', ';', '(', ')', '{', '}', '[', ']']
 
 # This is an incomplete list of Python builtins that should avoided in variable names
-NAME_CONFLICTS = {"all", "any", "bool", "class", "dict", "float", "input", "int", "list", "type"}
+RESERVED = {
+    "all",
+    "any",
+    "bool",
+    "class",
+    "dict",
+    "except",
+    "float",
+    "format",
+    "in",
+    "input",
+    "int",
+    "list",
+    "max",
+    "min",
+    "type",
+}
 CONFLICT_SUFFIX = "_"
 
 
@@ -180,7 +196,7 @@ if __name__ == "__main__":
     def function_name(self, s: str) -> str:
         """Get the function name for the provided string."""
         vname = to_snake_case(self._unspecial(s))
-        if vname in NAME_CONFLICTS:
+        if vname in RESERVED:
             return f"{vname}{CONFLICT_SUFFIX}"
 
         return vname
@@ -188,7 +204,7 @@ if __name__ == "__main__":
     def variable_name(self, s: str) -> str:
         """Get the variable name for the provided string."""
         vname = to_snake_case(self._unspecial(s))
-        if vname in NAME_CONFLICTS:
+        if vname in RESERVED:
             return f"{vname}{CONFLICT_SUFFIX}"
 
         return vname

--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -33,6 +33,10 @@ COLLECTIONS = {
 }
 SPECIAL_CHARS = ['/', '*', '.', '-', '@', ' ', '%', '<', '>', ':', ';', '(', ')', '{', '}', '[', ']']
 
+# This is an incomplete list of Python builtins that should avoided in variable names
+NAME_CONFLICTS = {"all", "any", "bool", "class", "dict", "float", "input", "int", "list", "type"}
+CONFLICT_PREFIX = "gen_"
+
 
 class Generator:
     """Provides the majority of the CLI generation functions.
@@ -175,15 +179,23 @@ if __name__ == "__main__":
 
     def function_name(self, s: str) -> str:
         """Get the function name for the provided string."""
-        return to_snake_case(self._unspecial(s))
+        vname = to_snake_case(self._unspecial(s))
+        if vname in NAME_CONFLICTS:
+            return f"{CONFLICT_PREFIX}{vname}"
+
+        return vname
 
     def variable_name(self, s: str) -> str:
         """Get the variable name for the provided string."""
-        return to_snake_case(self._unspecial(s))
+        vname = to_snake_case(self._unspecial(s))
+        if vname in NAME_CONFLICTS:
+            return f"{CONFLICT_PREFIX}{vname}"
+
+        return vname
 
     def option_name(self, s: str) -> str:
         """Get the typer option name for the provided string."""
-        value = self.variable_name(s)
+        value = to_snake_case(self._unspecial(s))
         return "--" + value.replace("_", "-")
 
     def model_is_complex(self, model: dict[str, Any]) -> bool:

--- a/tests/assets/misc.yaml
+++ b/tests/assets/misc.yaml
@@ -122,6 +122,10 @@ paths:
             - 3
             - four
             default: 1
+        - name: type
+          in: query
+          schema:
+            type: integer
       requestBody:
         content:
           application/json:
@@ -251,6 +255,9 @@ components:
               - type: boolean
               - type: integer
               - type: string
+          format:
+            type: string
+            default: text
 
     Pets:
       type: array

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -224,6 +224,10 @@ def test_schema_to_type(schema, fmt, expected):
             "SomeBraceAndBracketAndParenTesting",
             id="parens",
         ),
+        # these are the items that conflict with builtins
+        pytest.param("any", "Any", id="any"),
+        pytest.param("input", "Input", id="input"),
+        pytest.param("list", "List", id="list"),
     ]
 )
 def test_class_name(proposed, expected):
@@ -247,6 +251,10 @@ def test_class_name(proposed, expected):
             "some_brace_and_bracket_and_paren_testing",
             id="parens",
         ),
+        # these are the items that conflict with builtins
+        pytest.param("any", "gen_any", id="any"),
+        pytest.param("input", "gen_input", id="input"),
+        pytest.param("list", "gen_list", id="list"),
     ],
 )
 def test_function_name(proposed, expected):
@@ -270,6 +278,10 @@ def test_function_name(proposed, expected):
             "some_brace_and_bracket_and_paren_testing",
             id="parens",
         ),
+        # these are the items that conflict with builtins
+        pytest.param("any", "gen_any", id="any"),
+        pytest.param("input", "gen_input", id="input"),
+        pytest.param("list", "gen_list", id="list"),
     ],
 )
 def test_variable_name(proposed, expected):
@@ -293,6 +305,10 @@ def test_variable_name(proposed, expected):
             "--some-brace-and-bracket-and-paren-testing",
             id="parens",
         ),
+        # these are the items that conflict with builtins
+        pytest.param("any", "--any", id="any"),
+        pytest.param("input", "--input", id="input"),
+        pytest.param("list", "--list", id="list"),
     ],
 )
 def test_option_name(proposed, expected):

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -252,9 +252,9 @@ def test_class_name(proposed, expected):
             id="parens",
         ),
         # these are the items that conflict with builtins
-        pytest.param("any", "gen_any", id="any"),
-        pytest.param("input", "gen_input", id="input"),
-        pytest.param("list", "gen_list", id="list"),
+        pytest.param("any", "any_", id="any"),
+        pytest.param("input", "input_", id="input"),
+        pytest.param("list", "list_", id="list"),
     ],
 )
 def test_function_name(proposed, expected):
@@ -279,9 +279,9 @@ def test_function_name(proposed, expected):
             id="parens",
         ),
         # these are the items that conflict with builtins
-        pytest.param("any", "gen_any", id="any"),
-        pytest.param("input", "gen_input", id="input"),
-        pytest.param("list", "gen_list", id="list"),
+        pytest.param("any", "any_", id="any"),
+        pytest.param("input", "input_", id="input"),
+        pytest.param("list", "list_", id="list"),
     ],
 )
 def test_variable_name(proposed, expected):

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -180,7 +180,9 @@ def test_op_param_formation():
     if enum_with_default is not None:
         params["enumWithDefault"] = enum_with_default
     if str_enum_with_int_values is not None:
-        params["strEnumWithIntValues"] = str_enum_with_int_values\
+        params["strEnumWithIntValues"] = str_enum_with_int_values
+    if type_ is not None:
+        params["type"] = type_\
 """
     text = uut.op_param_formation(query_params)
     assert expected == text
@@ -428,6 +430,7 @@ def test_op_body_formation():
     assert 'body["firstChoice"] = first_choice' in text
     assert 'if list_various is not None:' in text
     assert 'body["listVarious"] = list_various' in text
+    assert 'body["format"] = format_' in text
 
 
 def test_op_path_arguments():
@@ -500,6 +503,10 @@ def test_op_query_arguments():
     )
     assert (
         'str_enum_with_int_values: Annotated[StrEnumWithIntValues, typer.Option(case_sensitive=False, help="")] = "1"'
+        in text
+    )
+    assert (
+        'type_: Annotated[Optional[int], typer.Option("--type", show_default=False, help="")] = None'
         in text
     )
 
@@ -1048,6 +1055,10 @@ def test_op_body_arguments():
     )
     assert (
         'list_various: Annotated[Optional[list[bool]], typer.Option(show_default=False)] = None'
+        in text
+    )
+    assert (
+        'format_: Annotated[Optional[str], typer.Option("--format")] = "text"'
         in text
     )
 


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

The parameter/property names may conflict with Python builtins. This causes confusion at best, and broken code in some cases.

## CHANGES
<!-- Please explain at a high-level the changes. -->

This adds a trailing `_` to those names to avoid the conflict. For optional parameters the function/variable name is ephemeral. However, for required path parameters, the variable name is displayed in the help, so the variable name should have as little change from the original parameter as possible.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->