### PR TITLE
Escape quoted strings

### DIFF
--- a/openapi_spec_tools/cli_gen/utils.py
+++ b/openapi_spec_tools/cli_gen/utils.py
@@ -26,14 +26,14 @@ def to_camel_case(text: str) -> str:
 def maybe_quoted(item: Any) -> str:
     """Add leading/trailing quotes to an item of type string, otherwise just convert item to a string."""
     if isinstance(item, str):
-        return f'"{item}"'
+        return quoted(item)
 
     return str(item)
 
 
 def quoted(s: str) -> str:
-    """Double quoted version of the provided string."""
-    return f'"{s}"'
+    """Double quote the provided string (and escape properly)."""
+    return f'"{s.translate(SIMPLE_TRANSLATIONS)}"'
 
 
 def simple_escape(text: str) -> str:

--- a/tests/cli_gen/test_utils.py
+++ b/tests/cli_gen/test_utils.py
@@ -45,6 +45,8 @@ def test_camel_case(text, expected):
         pytest.param(1, "1", id="int"),
         pytest.param(None, "None", id="none"),
         pytest.param(True, "True", id="bool"),
+        pytest.param("It's mine", '"It\\\'s mine"', id="single-quote"),
+        pytest.param('It is "mine"', '"It is \\\"mine\\\""', id="double-quote"),
     ]
 )
 def test_maybe_quoted(item, expected):


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Avoid issues with quotes in quoted strings. This impacts default values and help strings.

## CHANGES
<!-- Please explain at a high-level the changes. -->

When quoting a string with `quoted()`, make sure the string gets "encoded" to avoid unescaped quotes that cause problems in generated code.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->