### PR TITLE
Squash parameter schema on ingest

### DIFF
--- a/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/audit.py
+++ b/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/audit.py
@@ -114,7 +114,7 @@ def audit_list(
 
 @app.command("show", short_help="Retrieve one record from the audit log.")
 def audit_retrieve(
-    id: Annotated[str, typer.Argument(show_default=False, help="")],
+    id: Annotated[str, typer.Argument(show_default=False, help="A unique identifier for the audit record.")],
     _api_host: _a.ApiHostOption = "",
     _api_key: _a.ApiKeyOption = None,
     _api_timeout: _a.ApiTimeoutOption = 5,

--- a/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/environments.py
+++ b/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/environments.py
@@ -77,7 +77,7 @@ def environments_create(
 
 @app.command("delete", short_help="")
 def environments_destroy(
-    id: Annotated[str, typer.Argument(show_default=False, help="")],
+    id: Annotated[str, typer.Argument(show_default=False, help="A unique identifier for the environment.")],
     _api_host: _a.ApiHostOption = "",
     _api_key: _a.ApiKeyOption = None,
     _api_timeout: _a.ApiTimeoutOption = 5,
@@ -203,7 +203,7 @@ def environments_pushes_list(
 
 @app.command("set", short_help="")
 def environments_update(
-    id: Annotated[str, typer.Argument(show_default=False, help="")],
+    id: Annotated[str, typer.Argument(show_default=False, help="A unique identifier for the environment.")],
     name: Annotated[str, typer.Option(show_default=False, help="The environment name.")] = None,
     description: Annotated[Optional[str], typer.Option(show_default=False, help="A description of the environment.  You may find it helpful to document how this environment is used to assist others when they need to maintain software that uses this content.")] = None,
     parent: Annotated[Optional[str], typer.Option(show_default=False, help="Environments can inherit from a single parent environment which provides values for parameters when specific environments do not have a value set.  Every organization has one default environment that cannot be removed.")] = None,
@@ -279,7 +279,7 @@ def environments_retrieve(
 
 @app.command("update", short_help="")
 def environments_partial_update(
-    id: Annotated[str, typer.Argument(show_default=False, help="")],
+    id: Annotated[str, typer.Argument(show_default=False, help="A unique identifier for the environment.")],
     name: Annotated[Optional[str], typer.Option(show_default=False, help="The environment name.")] = None,
     description: Annotated[Optional[str], typer.Option(show_default=False, help="A description of the environment.  You may find it helpful to document how this environment is used to assist others when they need to maintain software that uses this content.")] = None,
     parent: Annotated[Optional[str], typer.Option(show_default=False, help="Environments can inherit from a single parent environment which provides values for parameters when specific environments do not have a value set.  Every organization has one default environment that cannot be removed.")] = None,

--- a/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/environments_tags.py
+++ b/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/environments_tags.py
@@ -87,7 +87,7 @@ def environments_tags_create(
 @app.command("delete", short_help="Tags allow you to name stable points for your configuration.")
 def environments_tags_destroy(
     environment_pk: Annotated[str, typer.Argument(show_default=False, help="")],
-    id: Annotated[str, typer.Argument(show_default=False, help="")],
+    id: Annotated[str, typer.Argument(show_default=False, help="A unique identifier for the tag.")],
     _api_host: _a.ApiHostOption = "",
     _api_key: _a.ApiKeyOption = None,
     _api_timeout: _a.ApiTimeoutOption = 5,
@@ -191,7 +191,7 @@ def environments_tags_list(
 @app.command("set", short_help="Tags allow you to name stable points for your configuration.")
 def environments_tags_update(
     environment_pk: Annotated[str, typer.Argument(show_default=False, help="")],
-    id: Annotated[str, typer.Argument(show_default=False, help="")],
+    id: Annotated[str, typer.Argument(show_default=False, help="A unique identifier for the tag.")],
     name: Annotated[str, typer.Option(show_default=False, help="The tag name. Tag names may contain alphanumeric, hyphen, underscore, or period characters. Tag names are case sensitive. The name cannot be modified.")] = None,
     description: Annotated[Optional[str], typer.Option(show_default=False, help="A description of the tag.  You may find it helpful to document how this tag is used to assist others when they need to maintain software that uses this content.")] = None,
     timestamp: Annotated[Optional[datetime], typer.Option(show_default=False, help="The point in time this tag represents.  If explicitly set to `null` then the current time will be used.")] = None,
@@ -243,7 +243,7 @@ def environments_tags_update(
 @app.command("show", short_help="Tags allow you to name stable points for your configuration.")
 def environments_tags_retrieve(
     environment_pk: Annotated[str, typer.Argument(show_default=False, help="")],
-    id: Annotated[str, typer.Argument(show_default=False, help="")],
+    id: Annotated[str, typer.Argument(show_default=False, help="A unique identifier for the tag.")],
     _api_host: _a.ApiHostOption = "",
     _api_key: _a.ApiKeyOption = None,
     _api_timeout: _a.ApiTimeoutOption = 5,
@@ -281,7 +281,7 @@ def environments_tags_retrieve(
 @app.command("update", short_help="Tags allow you to name stable points for your configuration.")
 def environments_tags_partial_update(
     environment_pk: Annotated[str, typer.Argument(show_default=False, help="")],
-    id: Annotated[str, typer.Argument(show_default=False, help="")],
+    id: Annotated[str, typer.Argument(show_default=False, help="A unique identifier for the tag.")],
     name: Annotated[Optional[str], typer.Option(show_default=False, help="The tag name. Tag names may contain alphanumeric, hyphen, underscore, or period characters. Tag names are case sensitive. The name cannot be modified.")] = None,
     description: Annotated[Optional[str], typer.Option(show_default=False, help="A description of the tag.  You may find it helpful to document how this tag is used to assist others when they need to maintain software that uses this content.")] = None,
     timestamp: Annotated[Optional[datetime], typer.Option(show_default=False, help="The point in time this tag represents.  If explicitly set to `null` then the current time will be used.")] = None,

--- a/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/grants.py
+++ b/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/grants.py
@@ -92,7 +92,7 @@ def grants_create(
 
 @app.command("delete", short_help="Grants allow you to enable access control on Environments and Projects.")
 def grants_destroy(
-    id: Annotated[str, typer.Argument(show_default=False, help="")],
+    id: Annotated[str, typer.Argument(show_default=False, help="A unique identifier for the grant.")],
     _api_host: _a.ApiHostOption = "",
     _api_key: _a.ApiKeyOption = None,
     _api_timeout: _a.ApiTimeoutOption = 5,
@@ -237,7 +237,7 @@ class RoleEnum(str, Enum):  # noqa: F811
 
 @app.command("set", short_help="Grants allow you to enable access control on Environments and Projects.")
 def grants_update(
-    id: Annotated[str, typer.Argument(show_default=False, help="")],
+    id: Annotated[str, typer.Argument(show_default=False, help="A unique identifier for the grant.")],
     principal: Annotated[str, typer.Option(show_default=False, help="The URI of a principal for the grant; this must reference a user or group.")] = None,
     scope: Annotated[str, typer.Option(show_default=False, help="The URI of a scope for the grant; this must reference a project or environment.")] = None,
     role: Annotated[RoleEnum, typer.Option(show_default=False, case_sensitive=False)] = None,
@@ -288,7 +288,7 @@ def grants_update(
 
 @app.command("show", short_help="Grants allow you to enable access control on Environments and Projects.")
 def grants_retrieve(
-    id: Annotated[str, typer.Argument(show_default=False, help="")],
+    id: Annotated[str, typer.Argument(show_default=False, help="A unique identifier for the grant.")],
     _api_host: _a.ApiHostOption = "",
     _api_key: _a.ApiKeyOption = None,
     _api_timeout: _a.ApiTimeoutOption = 5,
@@ -333,7 +333,7 @@ class RoleEnum(str, Enum):  # noqa: F811
 
 @app.command("update", short_help="Grants allow you to enable access control on Environments and Projects.")
 def grants_partial_update(
-    id: Annotated[str, typer.Argument(show_default=False, help="")],
+    id: Annotated[str, typer.Argument(show_default=False, help="A unique identifier for the grant.")],
     principal: Annotated[Optional[str], typer.Option(show_default=False, help="The URI of a principal for the grant; this must reference a user or group.")] = None,
     scope: Annotated[Optional[str], typer.Option(show_default=False, help="The URI of a scope for the grant; this must reference a project or environment.")] = None,
     role: Annotated[Optional[RoleEnum], typer.Option(show_default=False, case_sensitive=False)] = None,

--- a/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/memberships.py
+++ b/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/memberships.py
@@ -81,7 +81,7 @@ def memberships_create(
 
 @app.command("delete", short_help="")
 def memberships_destroy(
-    id: Annotated[str, typer.Argument(show_default=False, help="")],
+    id: Annotated[str, typer.Argument(show_default=False, help="A unique identifier for the membership.")],
     _api_host: _a.ApiHostOption = "",
     _api_key: _a.ApiKeyOption = None,
     _api_timeout: _a.ApiTimeoutOption = 5,
@@ -173,7 +173,7 @@ class RoleEnum(str, Enum):  # noqa: F811
 
 @app.command("set", short_help="")
 def memberships_update(
-    id: Annotated[str, typer.Argument(show_default=False, help="")],
+    id: Annotated[str, typer.Argument(show_default=False, help="A unique identifier for the membership.")],
     user: Annotated[str, typer.Option(show_default=False, help="The user of the membership.")] = None,
     organization: Annotated[str, typer.Option(show_default=False, help="The organization that the user is a member of.")] = None,
     role: Annotated[RoleEnum, typer.Option(show_default=False, case_sensitive=False)] = None,
@@ -217,7 +217,7 @@ def memberships_update(
 
 @app.command("show", short_help="")
 def memberships_retrieve(
-    id: Annotated[str, typer.Argument(show_default=False, help="")],
+    id: Annotated[str, typer.Argument(show_default=False, help="A unique identifier for the membership.")],
     _api_host: _a.ApiHostOption = "",
     _api_key: _a.ApiKeyOption = None,
     _api_timeout: _a.ApiTimeoutOption = 5,
@@ -255,7 +255,7 @@ class RoleEnum(str, Enum):  # noqa: F811
 
 @app.command("update", short_help="")
 def memberships_partial_update(
-    id: Annotated[str, typer.Argument(show_default=False, help="")],
+    id: Annotated[str, typer.Argument(show_default=False, help="A unique identifier for the membership.")],
     user: Annotated[Optional[str], typer.Option(show_default=False, help="The user of the membership.")] = None,
     organization: Annotated[Optional[str], typer.Option(show_default=False, help="The organization that the user is a member of.")] = None,
     role: Annotated[Optional[RoleEnum], typer.Option(show_default=False, case_sensitive=False)] = None,

--- a/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/users.py
+++ b/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/users.py
@@ -68,7 +68,7 @@ def users_current_retrieve(
 
 @app.command("delete", short_help="Delete the specified user.")
 def users_destroy(
-    id: Annotated[str, typer.Argument(show_default=False, help="")],
+    id: Annotated[str, typer.Argument(show_default=False, help="The unique identifier of a user.")],
     _api_host: _a.ApiHostOption = "",
     _api_key: _a.ApiKeyOption = None,
     _api_timeout: _a.ApiTimeoutOption = 5,
@@ -155,7 +155,7 @@ def users_list(
 
 @app.command("show", short_help="")
 def users_retrieve(
-    id: Annotated[str, typer.Argument(show_default=False, help="")],
+    id: Annotated[str, typer.Argument(show_default=False, help="The unique identifier of a user.")],
     _api_host: _a.ApiHostOption = "",
     _api_key: _a.ApiKeyOption = None,
     _api_timeout: _a.ApiTimeoutOption = 5,

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -337,12 +337,12 @@ def test_simplify_type(schema, expected):
     ["param_data", "expected"],
     [
         pytest.param({}, None, id="unknown"),
-        pytest.param({SCHEMA: {TYPE: "string"}}, "str", id="str"),
-        pytest.param({SCHEMA: {TYPE: "integer"}}, "int", id="int"),
-        pytest.param({SCHEMA: {TYPE: "numeric"}}, "float", id="float"),
-        pytest.param({SCHEMA: {TYPE: "string", ENUM: ["a", "b"]}, "name": "sna_foo"}, "SnaFoo", id="unref-enum"),
+        pytest.param({TYPE: "string"}, "str", id="str"),
+        pytest.param({TYPE: "integer"}, "int", id="int"),
+        pytest.param({TYPE: "numeric"}, "float", id="float"),
+        pytest.param({TYPE: "string", ENUM: ["a", "b"], "name": "sna_foo"}, "SnaFoo", id="unref-enum"),
         pytest.param(
-            {SCHEMA: {TYPE: "string", ENUM: ["a", "b"], "$ref": "#/comp/Schema/FooBar"}, "name": "sna_foo"},
+            {TYPE: "string", ENUM: ["a", "b"], "$ref": "#/comp/Schema/FooBar", "name": "sna_foo"},
             "FooBar",
             id="ref-enum",
         ),
@@ -572,16 +572,15 @@ class IntStrings(str, Enum):  # noqa: F811
 """
 
 SIMPLE_PARAM = {
-    SCHEMA: {
-        TYPE: "string", ENUM: ["aOrB", "b_or_C", "-minus"], "$ref": "#/components/schemas/Simple"
-    },
+    TYPE: "string",
+    ENUM: ["aOrB", "b_or_C", "-minus"], "$ref": "#/components/schemas/Simple",
     "name": "fooBar",
 }
 
-FOOBAR_PARAM = {SCHEMA: {TYPE: "string", ENUM: ["aOrB", "b_or_C", "-minus"]}, "name": "fooBar"}
-NUMBER_PARAM = {SCHEMA: {TYPE: "integer", ENUM: [12, 37, 11]}, "name": "simple-number"}
-MIXED_PARAM = {SCHEMA: {TYPE: "string", ENUM: ["a", 1, True, "b"]}, "name": "mixed-values"}
-INT_STR_PARAM = {SCHEMA: {TYPE: "string", ENUM: ["10", "10.1"]}, "name": "int-strings"}
+FOOBAR_PARAM = {TYPE: "string", ENUM: ["aOrB", "b_or_C", "-minus"], "name": "fooBar"}
+NUMBER_PARAM = {TYPE: "integer", ENUM: [12, 37, 11], "name": "simple-number"}
+MIXED_PARAM = {TYPE: "string", ENUM: ["a", 1, True, "b"], "name": "mixed-values"}
+INT_STR_PARAM = {TYPE: "string", ENUM: ["10", "10.1"], "name": "int-strings"}
 
 @pytest.mark.parametrize(
     ["name", "enum_type", "values", "expected"],
@@ -698,23 +697,23 @@ def test_enum_definitions(path_params, query_params, body_params, expected):
         pytest.param({}, {}, id="empty"),
         pytest.param(SIMPLE_PARAM, SIMPLE_PARAM, id="simple"),
         pytest.param(
-            {SCHEMA: {ONE_OF: [{TYPE: "foo"}, {TYPE: "array", ITEMS: {TYPE: "foo"}}]}},
-            {SCHEMA: {TYPE: "foo", COLLECT: "array"}},
+            {ONE_OF: [{TYPE: "foo"}, {TYPE: "array", ITEMS: {TYPE: "foo"}}]},
+            {TYPE: "foo", COLLECT: "array"},
             id="oneOf-collect-match"
         ),
         pytest.param(
-            {SCHEMA: {ONE_OF: [{TYPE: "foo"}, {TYPE: "array", ITEMS: {TYPE: "bar"}}]}},
-            {SCHEMA: {TYPE: "foo"}},
+            {ONE_OF: [{TYPE: "foo"}, {TYPE: "array", ITEMS: {TYPE: "bar"}}]},
+            {TYPE: "foo"},
             id="oneOf-collect-diff"
         ),
         pytest.param(
-            {SCHEMA: {TYPE: ["foo", "null"]}},
-            {SCHEMA: {TYPE: "foo"}, REQUIRED: False},
+            {TYPE: ["foo", "null"]},
+            {TYPE: "foo", REQUIRED: False},
             id="nullable"
         ),
         pytest.param(
-            {SCHEMA: {ANY_OF: [{TYPE: "array", ITEMS: {TYPE: "sna"}}, {TYPE: "foo"}]}},
-            {SCHEMA: {TYPE: "sna", COLLECT: "array"}},
+            {ANY_OF: [{TYPE: "array", ITEMS: {TYPE: "sna"}}, {TYPE: "foo"}]},
+            {TYPE: "sna", COLLECT: "array"},
             id="anyOf"
         ),
     ],


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Set the stage for more parameter manipulations. Having the extra `schema` layer adds challenges that need not be there.

## CHANGES
<!-- Please explain at a high-level the changes. -->

When pulling parameters for processing, move the `schema` data into the main object.
When processing parameter data, get info directly from the parameter data (instead of having to get some from `schema`).

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->