### PR TITLE
Allow layout sub-commands to have bugIds inside parent operation

### DIFF
--- a/openapi_spec_tools/cli_gen/layout.py
+++ b/openapi_spec_tools/cli_gen/layout.py
@@ -79,7 +79,9 @@ def data_to_node(data: dict[str, Any], identifier: str, command: str, item: dict
         sub_id = op_data.get(LayoutField.SUB_ID)
         if sub_id:
             # recursively go through this
-            children.append(data_to_node(data, sub_id, op_name, data.get(sub_id, {})))
+            subcommand = data_to_node(data, sub_id, op_name, data.get(sub_id, {}))
+            subcommand.bugs.extend(field_to_list(op_data, LayoutField.BUG_IDS))
+            children.append(subcommand)
             continue
 
         # use the current op-data to create a node -- it will be short

--- a/tests/cli_gen/test_layout_utils.py
+++ b/tests/cli_gen/test_layout_utils.py
@@ -284,6 +284,25 @@ def test_parse_pagination(data, expected) -> None:
             ),
             id="sub-cmds",
         ),
+        pytest.param(
+            "sna",
+            {
+                OPS: [
+                    {NAME: "foo", SUB_ID: "sub1"}, {NAME: "bar", SUB_ID: "sub2", "bugIds": "x, y"}
+                ],
+            },
+            LayoutNode(
+                command="sna",
+                identifier="sna",
+                children=[
+                    LayoutNode(command="foo", identifier="sub1", description="sub-command desc", children=[
+                        LayoutNode(command="dazed", identifier="confused"),
+                    ]),
+                    LayoutNode(command="bar", identifier="sub2", description="more help", bugs=["a", "bc", "x", "y"]),
+                ],
+            ),
+            id="sub-cmd-bug",
+        ),
     ],
 )
 def test_data_to_node_basic(name, item, expected) -> None:


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Inside the `layout.yaml` file, the sub-commands should support `bugIds` inside the operations section of parent.

For example:
```yaml
main:
  description: Manage CloudTruth application
  operations:
  - name: audit
    subcommandId: audit
    bugIds: ticket1
  - name: backup
    operationId: backup_snapshot_create

audit:
  description: View CloudTruth audit data
  bugIds: ticket2
  operations:
  - name: list
    operationId: audit_list
  - name: show
    operationId: audit_retrieve
```

Previously, the sub-commands had to have the `bugIds` in the definition of the sub-command. So, `ticket2` would have been detected, but not `ticket1`. With these changes, both will be detected.

## CHANGES
<!-- Please explain at a high-level the changes. -->

When dealing with sub-commands, add the list of bugs from the parent's operation to the sub-commands' bug list.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->