### PR TITLE
Fix issues with overlapping enum values

### DIFF
--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -378,10 +378,6 @@ if __name__ == "__main__":
                 prop_data[OasField.X_COLLECT.value] = collection_type
                 prop_data.update(item_model)
 
-            enum_values = prop_data.get(OasField.ENUM)
-            if enum_values:
-                prop_data[OasField.X_CASE_SENSITIVE.value] = is_case_sensitive(enum_values)
-
             required_sub = prop_data.get(OasField.REQUIRED, [])
             sub_properties = self.expanded_settable_properties(f"{name}.{prop_name}", prop_data)
             if not sub_properties:
@@ -618,7 +614,8 @@ if __name__ == "__main__":
                 arg_default = f" = {maybe_quoted(schema_default)}"
         is_enum = bool(param.get(OasField.ENUM))
         if is_enum:
-            typer_args.append(f"case_sensitive={param.get(OasField.X_CASE_SENSITIVE)}")
+            case_sensitive = is_case_sensitive(param.get(OasField.ENUM))
+            typer_args.append(f"case_sensitive={case_sensitive}")
             enum_type = param.get(OasField.TYPE)
             if enum_type == "string" and schema_default is not None:
                 arg_default = f" = {quoted(str(schema_default))}"
@@ -703,10 +700,6 @@ if __name__ == "__main__":
         if nullable:
             prop[OasField.REQUIRED.value] = False
 
-        enum_values = prop.get(OasField.ENUM)
-        if enum_values:
-            prop[OasField.X_CASE_SENSITIVE.value] = is_case_sensitive(enum_values)
-
         return prop
 
     def params_to_settable_properties(self, parameters: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -725,9 +718,6 @@ if __name__ == "__main__":
             model = deepcopy(self.get_model(ref))
             if not model.get(OasField.PROPS):
                 param.update(model)
-                enum_values = param.get(OasField.ENUM)
-                if enum_values:
-                    param[OasField.X_CASE_SENSITIVE.value] = is_case_sensitive(enum_values)
                 properties.append(param)
                 continue
 
@@ -759,7 +749,8 @@ if __name__ == "__main__":
                 if prop_data.get(OasField.TYPE) == "string" and def_val is not None:
                     # convert the default value to a string so it gets quoted
                     def_val = str(def_val)
-                t_args.append(f"case_sensitive={prop_data.get(OasField.X_CASE_SENSITIVE)}")
+                case_sensitive = is_case_sensitive(prop_data.get(OasField.ENUM))
+                t_args.append(f"case_sensitive={case_sensitive}")
             deprected = prop_data.get(OasField.DEPRECATED, False)
             x_deprecated = prop_data.get(OasField.X_DEPRECATED, None)
             if deprected or x_deprecated:

--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -33,7 +33,7 @@ SHEBANG = """\
 COLLECTIONS = {
     "array": "list",
 }
-SPECIAL_CHARS = ['/', '*', '.', '-', '@', ' ', '%', '<', '>', ':', ';', '(', ')', '{', '}', '[', ']']
+SPECIAL_CHARS = ['/', '*', '.', '-', '@', ' ', '%', '<', '>', ':', ';', '(', ')', '{', '}', '[', ']', '+']
 
 # This is an incomplete list of Python builtins that should avoided in variable names
 RESERVED = {
@@ -913,10 +913,17 @@ if __name__ == "__main__":
         if not all(self.clean_enum_name(v) for v in values):
             prefix = "VALUE_"
 
+        names = [self.variable_name(str(v)).upper() for v in values]
+        duplicates = set(x for x in names if names.count(x) > 1)
+        dup_counts = {x: 0 for x in duplicates}
         declarations = []
         for v in values:
             base_name = self.variable_name(str(v)).upper()
-            item_name = f"{prefix}{base_name}"
+            suffix = ""
+            if base_name in dup_counts:
+                suffix = dup_counts[base_name]
+                dup_counts[base_name] = suffix + 1
+            item_name = f"{prefix}{base_name}{suffix}"
             value = quoted(str(v)) if enum_type == "str" else maybe_quoted(v)
             declarations.append(f"{item_name} = {value}")
 

--- a/openapi_spec_tools/cli_gen/utils.py
+++ b/openapi_spec_tools/cli_gen/utils.py
@@ -65,3 +65,10 @@ def shallow(obj: dict[str, Any], max_len: int = 50) -> str:
         values.append(f"{k}: {item}")
 
     return "{" + ", ".join(values) + "}"
+
+
+def is_case_sensitive(values: list[Any]) -> bool:
+    """Determine if the provided values are case-sensitive."""
+    native = set(values)
+    lower = set(str(v).lower() for v in values)
+    return len(native) != len(lower)

--- a/openapi_spec_tools/types.py
+++ b/openapi_spec_tools/types.py
@@ -45,8 +45,7 @@ class OasField(str, Enum):
     X_PARENT = "x-parent"
     X_PATH = "x-path"
     X_PATH_PARAMS = "x-path-params"
-    X_REF = "x-reference"
-    X_CASE_SENSITIVE = "x-case-sensitive"
+    X_REF = 'x-reference'
 
 
 class ContentType(str, Enum):

--- a/openapi_spec_tools/types.py
+++ b/openapi_spec_tools/types.py
@@ -45,7 +45,8 @@ class OasField(str, Enum):
     X_PARENT = "x-parent"
     X_PATH = "x-path"
     X_PATH_PARAMS = "x-path-params"
-    X_REF = 'x-reference'
+    X_REF = "x-reference"
+    X_CASE_SENSITIVE = "x-case-sensitive"
 
 
 class ContentType(str, Enum):

--- a/tests/assets/misc.yaml
+++ b/tests/assets/misc.yaml
@@ -141,6 +141,10 @@ paths:
           in: query
           schema:
             $ref: '#/components/schemas/Address'
+        - name: favoriteDay
+          in: query
+          schema:
+            $ref: '#/components/schemas/DayOfWeek'
       requestBody:
         content:
           application/json:
@@ -277,6 +281,10 @@ components:
             description: To be removed
             x-deprecated: 5.6
             type: string
+          bestDay:
+            allOf:
+            - $ref: '#/components/schemas/DayOfWeek'
+            description: enum buried in all-of
 
     Pets:
       type: array
@@ -628,3 +636,11 @@ components:
       - $ref: '#/components/schemas/Pet'
       - $ref: '#/components/schemas/MissingItemsModel'
       type: object
+    DayOfWeek:
+      enum:
+        - FRIDAY
+        - friday
+        - SATURDAY
+        - saturday
+        - SUNDAY
+        - sunday

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -192,7 +192,9 @@ def test_op_param_formation():
         params["addr.city"] = addr_city
     if addr_state is not None:
         params["addr.state"] = addr_state
-    params["addr.zipCode"] = addr_zip_code\
+    params["addr.zipCode"] = addr_zip_code
+    if favorite_day is not None:
+        params["favoriteDay"] = favorite_day\
 """
     text = uut.op_param_formation(properties)
     assert expected == text
@@ -442,6 +444,8 @@ def test_op_body_formation():
     assert 'if gone is not None:' in text
     assert '_l.logger().warning("--gone was deprecated in 5.6 and should not be used")' in text
     assert 'body["gone"] = gone' in text
+    assert 'if best_day is not None' in text
+    assert 'body["bestDay"] = best_day' in text
 
 
 def test_op_path_arguments():
@@ -539,6 +543,11 @@ def test_op_query_arguments():
     )
     assert (
         'addr_zip_code: Annotated[Optional[str], typer.Option(show_default=False, help="")] = None'
+        in text
+    )
+    assert (
+        'favorite_day: Annotated[Optional[DayOfWeek], typer.Option(show_default=False, '
+        'case_sensitive=True, help="")] = None'
         in text
     )
 
@@ -1145,6 +1154,11 @@ def test_op_body_arguments():
     assert (
         'gone: Annotated[Optional[str], typer.Option(show_default=False, hidden=True, '
         'help="To be removed")] = None'
+        in text
+    )
+    assert (
+        'best_day: Annotated[Optional[DayOfWeek], typer.Option(show_default=False, '
+        'case_sensitive=True, help="enum buried in all-of")] = None'
         in text
     )
 

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -602,6 +602,18 @@ class IntStrings(str, Enum):  # noqa: F811
     VALUE_10 = "10"
     VALUE_10_1 = "10.1"
 """
+CASE_SENSE_ENUM = """\
+class Sna(str, Enum):  # noqa: F811
+    FOO0 = "foo"
+    FOO1 = "FOO"
+
+"""
+SPECIAL_ENUM = """\
+class Special(str, Enum):  # noqa: F811
+    _TIME0 = "-time"
+    _TIME1 = "+time"
+
+"""
 
 SIMPLE_PARAM = {
     TYPE: "string",
@@ -620,6 +632,8 @@ INT_STR_PARAM = {TYPE: "string", ENUM: ["10", "10.1"], "name": "int-strings"}
     [
         pytest.param("Simple", "str", ["aOrB", "b_or_C", "-minus"], SIMPLE_ENUM, id="str"),
         pytest.param("anyThing_goes", "int", [1, None, True], NON_STR_ENUM, id="non-str"),
+        pytest.param("Sna", "str", ["foo", "FOO"], CASE_SENSE_ENUM, id="case-sense"),
+        pytest.param("Special", "str", ["-time", "+time"], SPECIAL_ENUM, id="special"),
     ]
 )
 def test_enum_declaration(name, enum_type, values, expected):

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from pathlib import Path
 
 import pytest
@@ -615,8 +614,6 @@ NUMBER_PARAM = {TYPE: "integer", ENUM: [12, 37, 11], "name": "simple-number"}
 MIXED_PARAM = {TYPE: "string", ENUM: ["a", 1, True, "b"], "name": "mixed-values"}
 INT_STR_PARAM = {TYPE: "string", ENUM: ["10", "10.1"], "name": "int-strings"}
 
-SIMPLE_PROP = deepcopy(SIMPLE_PARAM)
-SIMPLE_PROP.update({"x-case-sensitive": False})
 
 @pytest.mark.parametrize(
     ["name", "enum_type", "values", "expected"],
@@ -731,7 +728,7 @@ def test_enum_definitions(path_params, query_params, body_params, expected):
     ["parameter", "expected"],
     [
         pytest.param({}, {}, id="empty"),
-        pytest.param(SIMPLE_PARAM, SIMPLE_PROP, id="simple"),
+        pytest.param(SIMPLE_PARAM, SIMPLE_PARAM, id="simple"),
         pytest.param(
             {ONE_OF: [{TYPE: "foo"}, {TYPE: "array", ITEMS: {TYPE: "foo"}}]},
             {TYPE: "foo", COLLECT: "array"},
@@ -819,7 +816,6 @@ def test_param_to_property(parameter, expected):
                     'required': True,
                     'x-reference': 'GeoJsonFeatureCollection',
                     'x-field': 'type',
-                    'x-case-sensitive': False,
                 },
                 'pagination.next':
                 {
@@ -874,7 +870,6 @@ def test_param_to_property(parameter, expected):
                     'enum': ['FeatureCollection'],
                     'type': 'string',
                     'required': True,
-                    'x-case-sensitive': False,
                 },
             },
             id="unnested",
@@ -950,7 +945,6 @@ def test_param_to_property(parameter, expected):
                     'type': 'string',
                     'x-field': 'type',
                     'x-reference': 'GeoJsonFeatureCollection',
-                    'x-case-sensitive': False,
                 },
             },
             id="nesting",
@@ -967,7 +961,6 @@ def test_param_to_property(parameter, expected):
                     'type': 'string',
                     '$ref': '#/components/schemas/Color',
                     'x-reference': 'Color',
-                    'x-case-sensitive': False,
                 },
                 'id': {
                     'pattern': '^[0-9a-fA-F]{24}$',
@@ -997,7 +990,6 @@ def test_param_to_property(parameter, expected):
                     'x-field': 'color',
                     'x-reference': 'Color',
                     '$ref': '#/components/schemas/Color',
-                    'x-case-sensitive': False,
                 },
             },
             id="list-all-of"
@@ -1018,7 +1010,6 @@ def test_param_to_property(parameter, expected):
                     'nullable': True,
                     'x-reference': 'Color',
                     'x-collection': 'array',
-                    'x-case-sensitive': False,
                 }
             },
             id="list-enum",

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from pathlib import Path
 
 import pytest
@@ -614,6 +615,9 @@ NUMBER_PARAM = {TYPE: "integer", ENUM: [12, 37, 11], "name": "simple-number"}
 MIXED_PARAM = {TYPE: "string", ENUM: ["a", 1, True, "b"], "name": "mixed-values"}
 INT_STR_PARAM = {TYPE: "string", ENUM: ["10", "10.1"], "name": "int-strings"}
 
+SIMPLE_PROP = deepcopy(SIMPLE_PARAM)
+SIMPLE_PROP.update({"x-case-sensitive": False})
+
 @pytest.mark.parametrize(
     ["name", "enum_type", "values", "expected"],
     [
@@ -727,7 +731,7 @@ def test_enum_definitions(path_params, query_params, body_params, expected):
     ["parameter", "expected"],
     [
         pytest.param({}, {}, id="empty"),
-        pytest.param(SIMPLE_PARAM, SIMPLE_PARAM, id="simple"),
+        pytest.param(SIMPLE_PARAM, SIMPLE_PROP, id="simple"),
         pytest.param(
             {ONE_OF: [{TYPE: "foo"}, {TYPE: "array", ITEMS: {TYPE: "foo"}}]},
             {TYPE: "foo", COLLECT: "array"},
@@ -815,6 +819,7 @@ def test_param_to_property(parameter, expected):
                     'required': True,
                     'x-reference': 'GeoJsonFeatureCollection',
                     'x-field': 'type',
+                    'x-case-sensitive': False,
                 },
                 'pagination.next':
                 {
@@ -869,6 +874,7 @@ def test_param_to_property(parameter, expected):
                     'enum': ['FeatureCollection'],
                     'type': 'string',
                     'required': True,
+                    'x-case-sensitive': False,
                 },
             },
             id="unnested",
@@ -944,6 +950,7 @@ def test_param_to_property(parameter, expected):
                     'type': 'string',
                     'x-field': 'type',
                     'x-reference': 'GeoJsonFeatureCollection',
+                    'x-case-sensitive': False,
                 },
             },
             id="nesting",
@@ -960,6 +967,7 @@ def test_param_to_property(parameter, expected):
                     'type': 'string',
                     '$ref': '#/components/schemas/Color',
                     'x-reference': 'Color',
+                    'x-case-sensitive': False,
                 },
                 'id': {
                     'pattern': '^[0-9a-fA-F]{24}$',
@@ -988,7 +996,8 @@ def test_param_to_property(parameter, expected):
                     'nullable': True,
                     'x-field': 'color',
                     'x-reference': 'Color',
-                    '$ref': '#/components/schemas/Color'
+                    '$ref': '#/components/schemas/Color',
+                    'x-case-sensitive': False,
                 },
             },
             id="list-all-of"
@@ -1009,6 +1018,7 @@ def test_param_to_property(parameter, expected):
                     'nullable': True,
                     'x-reference': 'Color',
                     'x-collection': 'array',
+                    'x-case-sensitive': False,
                 }
             },
             id="list-enum",

--- a/tests/cli_gen/test_utils.py
+++ b/tests/cli_gen/test_utils.py
@@ -1,5 +1,6 @@
 import pytest
 
+from openapi_spec_tools.cli_gen.utils import is_case_sensitive
 from openapi_spec_tools.cli_gen.utils import maybe_quoted
 from openapi_spec_tools.cli_gen.utils import shallow
 from openapi_spec_tools.cli_gen.utils import to_camel_case
@@ -70,3 +71,16 @@ def test_maybe_quoted(item, expected):
 )
 def test_shallow(obj, expected):
     assert expected == shallow(obj)
+
+
+@pytest.mark.parametrize(
+    ["items", "expected"],
+    [
+        pytest.param([], False, id="empty"),
+        pytest.param(["a", "B", 1, False], False, id="simple"),
+        pytest.param(["a", "B", "A"], True, id="overlap"),
+        pytest.param(["a", "a"], False, id="duplicate"),
+    ]
+)
+def test_is_case_sensitive(items, expected):
+    assert expected == is_case_sensitive(items)


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

This takes care of two related issues with enumerations:
1. Properly set the `typer` value for case-sensitivity
2. Avoid duplicate names in enum declaration

## CHANGES
<!-- Please explain at a high-level the changes. -->

When adding the enum value to the `typer` object (`Option` or `Argument`), set `case_sensitive` based on whether or not there are values that are the same other than case.

When creating the enum declaration, add a numeric suffix with the value's name overlaps with another value.


<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->