### PR TITLE
Fix issues with sub-objects in request bodies

### DIFF
--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -12,6 +12,7 @@ from openapi_spec_tools.cli_gen.constants import GENERATOR_LOG_CLASS
 from openapi_spec_tools.cli_gen.layout_types import LayoutNode
 from openapi_spec_tools.cli_gen.utils import is_case_sensitive
 from openapi_spec_tools.cli_gen.utils import maybe_quoted
+from openapi_spec_tools.cli_gen.utils import prepend
 from openapi_spec_tools.cli_gen.utils import quoted
 from openapi_spec_tools.cli_gen.utils import set_missing
 from openapi_spec_tools.cli_gen.utils import shallow
@@ -406,7 +407,7 @@ if __name__ == "__main__":
                 if reference:
                     set_missing(sub_data, OasField.X_REF.value, self.short_reference_name(reference))
                 set_missing(sub_data, OasField.X_FIELD.value, sub_name)
-                set_missing(sub_data, OasField.X_PARENT.value, prop_name)
+                prepend(sub_data, OasField.X_PARENTS.value, prop_name)
                 properties[full_name] = sub_data
 
         return properties

--- a/openapi_spec_tools/cli_gen/utils.py
+++ b/openapi_spec_tools/cli_gen/utils.py
@@ -44,6 +44,13 @@ def simple_escape(text: str) -> str:
     return lines[0].translate(SIMPLE_TRANSLATIONS)
 
 
+def prepend(obj: dict[str, Any], key: str, value: Any) -> None:
+    """Prepend the value into the object/key list of items."""
+    items = obj.get(key) or []
+    items.insert(0, value)
+    obj[key] = items
+
+
 def set_missing(obj: dict[str, Any], key: str, value: Any) -> None:
     """Set key/value into obj if the key is NOT already in the object."""
     if key not in obj:

--- a/openapi_spec_tools/types.py
+++ b/openapi_spec_tools/types.py
@@ -42,10 +42,10 @@ class OasField(str, Enum):
     X_COLLECT = "x-collection"
     X_FIELD = "x-field"
     X_METHOD = "x-method"
-    X_PARENT = "x-parent"
+    X_PARENTS = "x-parents"
     X_PATH = "x-path"
     X_PATH_PARAMS = "x-path-params"
-    X_REF = 'x-reference'
+    X_REF = "x-reference"
 
 
 class ContentType(str, Enum):

--- a/tests/assets/misc.yaml
+++ b/tests/assets/misc.yaml
@@ -285,6 +285,8 @@ components:
             allOf:
             - $ref: '#/components/schemas/DayOfWeek'
             description: enum buried in all-of
+          owner:
+            $ref: '#/components/schemas/Owner'
 
     Pets:
       type: array

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -447,6 +447,18 @@ def test_op_body_formation():
     assert 'if best_day is not None' in text
     assert 'body["bestDay"] = best_day' in text
 
+    # this is for the sub-object -- just check the infra and a couple properties
+    assert 'owner = {}' in text
+    assert 'home = {}' in text
+    assert 'if owner_home_street is not None' in text
+    assert 'home["street"] = owner_home_street' in text
+    assert 'if owner_home_zip_code is not None' in text
+    assert 'home["zipCode"] = owner_home_zip_code' in text
+    assert 'if home:' in text
+    assert 'owner["home"] = home' in text
+    assert 'if owner:' in text
+    assert 'body["owner"] = owner' in text
+
 
 def test_op_path_arguments():
     oas = open_oas(asset_filename("misc.yaml"))

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -798,14 +798,14 @@ def test_param_to_property(parameter, expected):
                     'type': 'string',
                     'required': False,
                     'x-reference': 'Address',
-                    'x-parent': 'home',
+                    'x-parents': ['home'],
                     'x-field': 'street',
                 },
                 'home.city': {
                     'type': 'string',
                     'required': False,
                     'x-reference': 'Address',
-                    'x-parent': 'home',
+                    'x-parents': ['home'],
                     'x-field': 'city',
                 },
                 'home.state': {
@@ -813,14 +813,14 @@ def test_param_to_property(parameter, expected):
                     'required': False,
                     'x-reference': 'Address',
                     'x-field': 'state',
-                    'x-parent': 'home',
+                    'x-parents': ['home'],
                 },
                 'home.zipCode': {
                     'type': 'string',
                     'required': False,
                     'x-reference': 'Address',
                     'x-field': 'zipCode',
-                    'x-parent': 'home',
+                    'x-parents': ['home'],
                 },
                 'iceCream': {
                     'type': 'string',
@@ -847,7 +847,7 @@ def test_param_to_property(parameter, expected):
                     'required': False,
                     'type': 'string',
                     'x-field': 'next',
-                    'x-parent': 'pagination',
+                    'x-parents': ['pagination'],
                     'x-reference': 'PaginationInfo',
                 },
                 'observationStations': {
@@ -912,14 +912,14 @@ def test_param_to_property(parameter, expected):
                     'required': False,
                     'type': 'string',
                     'x-field': 'city',
-                    'x-parent': 'home',
+                    'x-parents': ['owner', 'home'],
                     'x-reference': 'Address',
                 },
                 'owner.home.state': {
                     'required': False,
                     'type': 'string',
                     'x-field': 'state',
-                    'x-parent': 'home',
+                    'x-parents': ['owner', 'home'],
                     'x-reference': 'Address',
                 },
                 'owner.home.street': {
@@ -927,14 +927,14 @@ def test_param_to_property(parameter, expected):
                     'required': False,
                     'type': 'string',
                     'x-field': 'street',
-                    'x-parent': 'home',
+                    'x-parents': ['owner', 'home'],
                     'x-reference': 'Address',
                 },
                 'owner.home.zipCode': {
                     'required': False,
                     'type': 'string',
                     'x-field': 'zipCode',
-                    'x-parent': 'home',
+                    'x-parents': ['owner', 'home'],
                     'x-reference': 'Address',
                 },
                 'owner.iceCream': {
@@ -942,7 +942,7 @@ def test_param_to_property(parameter, expected):
                     'required': False,
                     'type': 'string',
                     'x-field': 'iceCream',
-                    'x-parent': 'owner',
+                    'x-parents': ['owner'],
                     'x-reference': 'Owner',
                 },
                 'owner.name': {
@@ -950,7 +950,7 @@ def test_param_to_property(parameter, expected):
                     'required': False,
                     'type': 'string',
                     'x-field': 'name',
-                    'x-parent': 'owner',
+                    'x-parents': ['owner'],
                     'x-reference': 'Person',
                 },
                 'pagination.next': {
@@ -959,7 +959,7 @@ def test_param_to_property(parameter, expected):
                     'required': False,
                     'type': 'string',
                     'x-field': 'next',
-                    'x-parent': 'pagination',
+                    'x-parents': ['pagination'],
                     'x-reference': 'PaginationInfo',
                 },
                 'type': {

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -459,6 +459,9 @@ def test_op_body_formation():
     assert 'if owner:' in text
     assert 'body["owner"] = owner' in text
 
+    # make sure sub-object is populated before checking if it is populated
+    assert text.find('if home:') < text.find('if owner:')
+
 
 def test_op_path_arguments():
     oas = open_oas(asset_filename("misc.yaml"))

--- a/tests/cli_gen/test_utils.py
+++ b/tests/cli_gen/test_utils.py
@@ -2,6 +2,8 @@ import pytest
 
 from openapi_spec_tools.cli_gen.utils import is_case_sensitive
 from openapi_spec_tools.cli_gen.utils import maybe_quoted
+from openapi_spec_tools.cli_gen.utils import prepend
+from openapi_spec_tools.cli_gen.utils import set_missing
 from openapi_spec_tools.cli_gen.utils import shallow
 from openapi_spec_tools.cli_gen.utils import to_camel_case
 from openapi_spec_tools.cli_gen.utils import to_snake_case
@@ -53,6 +55,30 @@ def test_camel_case(text, expected):
 )
 def test_maybe_quoted(item, expected):
     assert expected == maybe_quoted(item)
+
+
+@pytest.mark.parametrize(
+    ["obj", "name", "value", "expected"],
+    [
+        pytest.param({"a": "b"}, "c", "d", {"a": "b", "c": ["d"]}, id="added"),
+        pytest.param({"a": "b", "c": ["d"]}, "c", "e", {"a": "b", "c": ["e", "d"]}, id="inserted"),
+        pytest.param({"a": "b", "c": None}, "c", "e", {"a": "b", "c": ["e"]}, id="none"),
+    ]
+)
+def test_prepend(obj, name, value, expected):
+    prepend(obj, name, value)
+    assert expected == obj
+
+@pytest.mark.parametrize(
+    ["obj", "name", "value", "expected"],
+    [
+        pytest.param({"a": "b"}, "c", True, {"a": "b", "c": True}, id="missing"),
+        pytest.param({"a": "b"}, "a", 1, {"a": "b"}, id="exists"),
+    ],
+)
+def test_set_missing(obj, name, value, expected):
+    set_missing(obj, name, value)
+    assert expected == obj
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Some request bodies have sub-objects and the bodies should be properly formed.

## CHANGES
<!-- Please explain at a high-level the changes. -->

First change was to update the parent tracking field (now `x-parents`) to be a list of parents, so the whole lineage could be setup during body formation.

During body formation, all the sub-objects needed to be instantiated and populated. The instantiation just used the last parent in the list. The population used the last parent as the sub-object and the `x-field` value to update the correct field within the sub-object.

The ordering of stitching together of the sub-objects into their parents was a little tricky due to ordering issues. The sub-objects need to be populated prior to checking if they're populated (and adding them to their parent). 

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->