### PR TITLE
Move Generator._unspecial() to utilities replace_special()

### DIFF
--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -14,6 +14,7 @@ from openapi_spec_tools.cli_gen.utils import is_case_sensitive
 from openapi_spec_tools.cli_gen.utils import maybe_quoted
 from openapi_spec_tools.cli_gen.utils import prepend
 from openapi_spec_tools.cli_gen.utils import quoted
+from openapi_spec_tools.cli_gen.utils import replace_special
 from openapi_spec_tools.cli_gen.utils import set_missing
 from openapi_spec_tools.cli_gen.utils import shallow
 from openapi_spec_tools.cli_gen.utils import simple_escape
@@ -34,7 +35,6 @@ SHEBANG = """\
 COLLECTIONS = {
     "array": "list",
 }
-SPECIAL_CHARS = ['/', '*', '.', '-', '@', ' ', '%', '<', '>', ':', ';', '(', ')', '{', '}', '[', ']', '+']
 
 # This is an incomplete list of Python builtins that should avoided in variable names
 RESERVED = {
@@ -192,20 +192,14 @@ if __name__ == "__main__":
 
         return None
 
-    def _unspecial(self, value: str, replacement: str = '_') -> str:
-        """Replace the "special" characters with the replacement."""
-        for v in SPECIAL_CHARS:
-            value = value.replace(v, replacement)
-        return value
-
     def class_name(self, s: str) -> str:
         """Get the class name for provided string."""
-        value = to_camel_case(self._unspecial(s))
+        value = to_camel_case(replace_special(s))
         return value[0].upper() + value[1:]
 
     def function_name(self, s: str) -> str:
         """Get the function name for the provided string."""
-        vname = to_snake_case(self._unspecial(s))
+        vname = to_snake_case(replace_special(s))
         if vname in RESERVED:
             return f"{vname}{CONFLICT_SUFFIX}"
 
@@ -213,7 +207,7 @@ if __name__ == "__main__":
 
     def variable_name(self, s: str) -> str:
         """Get the variable name for the provided string."""
-        vname = to_snake_case(self._unspecial(s))
+        vname = to_snake_case(replace_special(s))
         if vname in RESERVED:
             return f"{vname}{CONFLICT_SUFFIX}"
 
@@ -221,7 +215,7 @@ if __name__ == "__main__":
 
     def option_name(self, s: str) -> str:
         """Get the typer option name for the provided string."""
-        value = to_snake_case(self._unspecial(s))
+        value = to_snake_case(replace_special(s))
         return "--" + value.replace("_", "-")
 
     def model_is_complex(self, model: dict[str, Any]) -> bool:

--- a/openapi_spec_tools/cli_gen/utils.py
+++ b/openapi_spec_tools/cli_gen/utils.py
@@ -9,6 +9,14 @@ SIMPLE_TRANSLATIONS = str.maketrans(
         '"': r"\"",
     },
 )
+SPECIAL_CHARS = [
+    # mathematical
+    '/', '*', '+', '-', '^', '%', '&', '|', '~', '<', '>','=',
+    # operators/punctional
+    '.', '@', ' ', ':', ';', '#', ',', '!', '`', '?', '\'', '"',
+    # parenthesis/brackets
+    '(', ')', '{', '}', '[', ']',
+]
 
 
 def to_snake_case(text: str) -> str:
@@ -34,6 +42,14 @@ def maybe_quoted(item: Any) -> str:
 def quoted(s: str) -> str:
     """Double quote the provided string (and escape properly)."""
     return f'"{s.translate(SIMPLE_TRANSLATIONS)}"'
+
+
+def replace_special(value: str, replacement: str = '_') -> str:
+    """Replace the "special" characters with the replacement."""
+    _replacement = '' if replacement is None else replacement
+    for v in SPECIAL_CHARS:
+        value = value.replace(v, _replacement)
+    return value
 
 
 def simple_escape(text: str) -> str:

--- a/tests/cli_gen/test_utils.py
+++ b/tests/cli_gen/test_utils.py
@@ -76,6 +76,7 @@ def test_prepend(obj, name, value, expected):
     [
         pytest.param("", "_", "", id="empty"),
         pytest.param("a+b", "_", "a_b", id="underscore"),
+        pytest.param("a+b", "*", "a*b", id="star"),
         pytest.param("a*b", None, "ab", id="none"),
     ]
 )

--- a/tests/cli_gen/test_utils.py
+++ b/tests/cli_gen/test_utils.py
@@ -3,6 +3,7 @@ import pytest
 from openapi_spec_tools.cli_gen.utils import is_case_sensitive
 from openapi_spec_tools.cli_gen.utils import maybe_quoted
 from openapi_spec_tools.cli_gen.utils import prepend
+from openapi_spec_tools.cli_gen.utils import replace_special
 from openapi_spec_tools.cli_gen.utils import set_missing
 from openapi_spec_tools.cli_gen.utils import shallow
 from openapi_spec_tools.cli_gen.utils import to_camel_case
@@ -68,6 +69,20 @@ def test_maybe_quoted(item, expected):
 def test_prepend(obj, name, value, expected):
     prepend(obj, name, value)
     assert expected == obj
+
+
+@pytest.mark.parametrize(
+    ["orig", "replacement", "expected"],
+    [
+        pytest.param("", "_", "", id="empty"),
+        pytest.param("a+b", "_", "a_b", id="underscore"),
+        pytest.param("a*b", None, "ab", id="none"),
+    ]
+)
+def test_replace_special(orig, replacement, expected):
+    actual = replace_special(orig, replacement)
+    assert expected == actual
+
 
 @pytest.mark.parametrize(
     ["obj", "name", "value", "expected"],


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Move `Generator._unspecial()` to utils `replace_special()`.

## CHANGES
<!-- Please explain at a high-level the changes. -->

* Move/rename function
* Added a few more special characters
* Added direct unit test

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->