### PR TITLE
Include enums from header parameters

### DIFF
--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -1075,7 +1075,7 @@ if __name__ == "__main__":
             user_header_init = NL + SEP1 + SEP1.join(lines) + NL
 
         return f"""
-{self.enum_definitions(path_params, query_params, body_params)}
+{self.enum_definitions(path_params, query_params + header_params, body_params)}
 @app.command({', '.join(command_args)})
 def {func_name}({args_str}) -> None:
     {self.op_long_help(op)}# handler for {node.identifier}: {method} {path}

--- a/tests/assets/misc.yaml
+++ b/tests/assets/misc.yaml
@@ -145,6 +145,10 @@ paths:
           in: query
           schema:
             $ref: '#/components/schemas/DayOfWeek'
+        - name: color
+          in: header
+          schema:
+            $ref: '#/components/schemas/Color'
       requestBody:
         content:
           application/json:

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -1434,9 +1434,16 @@ def test_function_header_params():
     uut = Generator("cli_package", oas)
     text = uut.function_definition(item)
 
+    # check that the header enums are defined -- no need to check all the fields of each enum
+    assert 'class Color(str, Enum):' in text
+
     # check function argument (aka CLI option)
     assert (
         'has_param: Annotated[Optional[int], typer.Option(show_default=False, help="Parameter in header")] = None'
+        in text
+    )
+    assert (
+        'color: Annotated[Optional[Color], typer.Option(show_default=False, case_sensitive=False, help="")] = None'
         in text
     )
 


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Fix issue where enumeration definitions from header parameters were not included.

## CHANGES
<!-- Please explain at a high-level the changes. -->

Added header parameters to the query parameters in call to declare enumeration definitions.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->