### PR TITLE
Split PageParams instantiation into multiple lines

### DIFF
--- a/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/audit.py
+++ b/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/audit.py
@@ -70,7 +70,15 @@ def audit_list(
     _l.init_logging(_log_level)
     headers = _r.request_headers(_api_key)
     url = _r.create_url(_api_host, "api/v1/audit/")
-    page_info = _r.PageParams(max_count=_max_count, page_size_name="page_size", page_size_value=page_size, page_start_name="page", page_start_value=page, item_property_name="result", next_property_name="next")
+    page_info = _r.PageParams(
+        max_count=_max_count,
+        page_size_name="page_size",
+        page_size_value=page_size,
+        page_start_name="page",
+        page_start_value=page,
+        item_property_name="result",
+        next_property_name="next",
+    )
     missing = []
     if _api_key is None:
         missing.append("--api-key")

--- a/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/environments.py
+++ b/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/environments.py
@@ -126,7 +126,15 @@ def environments_list(
     _l.init_logging(_log_level)
     headers = _r.request_headers(_api_key)
     url = _r.create_url(_api_host, "api/v1/environments/")
-    page_info = _r.PageParams(max_count=_max_count, page_size_name="page_size", page_size_value=page_size, page_start_name="page", page_start_value=page, item_property_name="result", next_property_name="next")
+    page_info = _r.PageParams(
+        max_count=_max_count,
+        page_size_name="page_size",
+        page_size_value=page_size,
+        page_start_name="page",
+        page_start_value=page,
+        item_property_name="result",
+        next_property_name="next",
+    )
     missing = []
     if _api_key is None:
         missing.append("--api-key")
@@ -177,7 +185,15 @@ def environments_pushes_list(
     _l.init_logging(_log_level)
     headers = _r.request_headers(_api_key)
     url = _r.create_url(_api_host, "api/v1/environments", environment_pk, "pushes/")
-    page_info = _r.PageParams(max_count=_max_count, page_size_name="page_size", page_size_value=page_size, page_start_name="page", page_start_value=page, item_property_name="result", next_property_name="next")
+    page_info = _r.PageParams(
+        max_count=_max_count,
+        page_size_name="page_size",
+        page_size_value=page_size,
+        page_start_name="page",
+        page_start_value=page,
+        item_property_name="result",
+        next_property_name="next",
+    )
     missing = []
     if _api_key is None:
         missing.append("--api-key")

--- a/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/environments_tags.py
+++ b/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/environments_tags.py
@@ -152,7 +152,15 @@ def environments_tags_list(
     _l.init_logging(_log_level)
     headers = _r.request_headers(_api_key)
     url = _r.create_url(_api_host, "api/v1/environments", environment_pk, "tags/")
-    page_info = _r.PageParams(max_count=_max_count, page_size_name="page_size", page_size_value=page_size, page_start_name="page", page_start_value=page, item_property_name="result", next_property_name="next")
+    page_info = _r.PageParams(
+        max_count=_max_count,
+        page_size_name="page_size",
+        page_size_value=page_size,
+        page_start_name="page",
+        page_start_value=page,
+        item_property_name="result",
+        next_property_name="next",
+    )
     missing = []
     if _api_key is None:
         missing.append("--api-key")

--- a/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/grants.py
+++ b/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/grants.py
@@ -198,7 +198,15 @@ def grants_list(
     _l.init_logging(_log_level)
     headers = _r.request_headers(_api_key)
     url = _r.create_url(_api_host, "api/v1/grants/")
-    page_info = _r.PageParams(max_count=_max_count, page_size_name="page_size", page_size_value=page_size, page_start_name="page", page_start_value=page, item_property_name="result", next_property_name="next")
+    page_info = _r.PageParams(
+        max_count=_max_count,
+        page_size_name="page_size",
+        page_size_value=page_size,
+        page_start_name="page",
+        page_start_value=page,
+        item_property_name="result",
+        next_property_name="next",
+    )
     missing = []
     if _api_key is None:
         missing.append("--api-key")

--- a/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/memberships.py
+++ b/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/memberships.py
@@ -136,7 +136,15 @@ def memberships_list(
     _l.init_logging(_log_level)
     headers = _r.request_headers(_api_key)
     url = _r.create_url(_api_host, "api/v1/memberships/")
-    page_info = _r.PageParams(max_count=_max_count, page_size_name="page_size", page_size_value=page_size, page_start_name="page", page_start_value=page, item_property_name="result", next_property_name="next")
+    page_info = _r.PageParams(
+        max_count=_max_count,
+        page_size_name="page_size",
+        page_size_value=page_size,
+        page_start_name="page",
+        page_start_value=page,
+        item_property_name="result",
+        next_property_name="next",
+    )
     missing = []
     if _api_key is None:
         missing.append("--api-key")

--- a/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/users.py
+++ b/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/users.py
@@ -127,7 +127,15 @@ def users_list(
     _l.init_logging(_log_level)
     headers = _r.request_headers(_api_key)
     url = _r.create_url(_api_host, "api/v1/users/")
-    page_info = _r.PageParams(max_count=_max_count, page_size_name="page_size", page_size_value=page_size, page_start_name="page", page_start_value=page, item_property_name="result", next_property_name="next")
+    page_info = _r.PageParams(
+        max_count=_max_count,
+        page_size_name="page_size",
+        page_size_value=page_size,
+        page_start_name="page",
+        page_start_value=page,
+        item_property_name="result",
+        next_property_name="next",
+    )
     missing = []
     if _api_key is None:
         missing.append("--api-key")

--- a/examples/github/github_gen_cli/users.py
+++ b/examples/github/github_gen_cli/users.py
@@ -70,7 +70,11 @@ def users_list_attestations(
     _l.init_logging(_log_level)
     headers = _r.request_headers(_api_key)
     url = _r.create_url(_api_host, "users", username, "attestations", subject_digest)
-    page_info = _r.PageParams(max_count=_max_count, page_size_name="per-page", page_size_value=per_page)
+    page_info = _r.PageParams(
+        max_count=_max_count,
+        page_size_name="per-page",
+        page_size_value=per_page,
+    )
     missing = []
     if _api_key is None:
         missing.append("--api-key")
@@ -154,7 +158,11 @@ def users_list(
     _l.init_logging(_log_level)
     headers = _r.request_headers(_api_key)
     url = _r.create_url(_api_host, "users")
-    page_info = _r.PageParams(max_count=_max_count, page_size_name="per-page", page_size_value=per_page)
+    page_info = _r.PageParams(
+        max_count=_max_count,
+        page_size_name="per-page",
+        page_size_value=per_page,
+    )
     missing = []
     if _api_key is None:
         missing.append("--api-key")

--- a/examples/github/github_gen_cli/users_blocks.py
+++ b/examples/github/github_gen_cli/users_blocks.py
@@ -52,7 +52,13 @@ def users_list_blocked_by_authenticated_user(
     _l.init_logging(_log_level)
     headers = _r.request_headers(_api_key)
     url = _r.create_url(_api_host, "user/blocks")
-    page_info = _r.PageParams(max_count=_max_count, page_size_name="per-page", page_size_value=per_page, page_start_name="page", page_start_value=page)
+    page_info = _r.PageParams(
+        max_count=_max_count,
+        page_size_name="per-page",
+        page_size_value=per_page,
+        page_start_name="page",
+        page_start_value=page,
+    )
     missing = []
     if _api_key is None:
         missing.append("--api-key")

--- a/examples/pets-cli/pets_cli/main.py
+++ b/examples/pets-cli/pets_cli/main.py
@@ -134,7 +134,11 @@ def list_pets(
     _l.init_logging(_log_level)
     headers = _r.request_headers(_api_key)
     url = _r.create_url(_api_host, "pets")
-    page_info = _r.PageParams(max_count=_max_count, page_size_name="limit", page_size_value=limit)
+    page_info = _r.PageParams(
+        max_count=_max_count,
+        page_size_name="limit",
+        page_size_value=limit,
+    )
     missing = []
     if _api_key is None:
         missing.append("--api-key")

--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -937,8 +937,8 @@ if __name__ == "__main__":
         if names.next_property:
             args["next_property_name"] = quoted(names.next_property)
 
-        arg_text = ', '.join([f"{k}={v}" for k, v in args.items()])
-        return f"{SEP1}page_info = _r.PageParams({arg_text})"
+        arg_text = ','.join([f"{SEP2}{k}={v}" for k, v in args.items()])
+        return f"{SEP1}page_info = _r.PageParams({arg_text},{SEP1})"
 
     def clean_enum_name(self, value: str) -> bool:
         """Check to see if value can be directly used as a variable name."""

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -23,6 +23,9 @@ ANY_OF = "anyOf"
 ONE_OF = "oneOf"
 ITEMS = "items"
 
+S1 = '\n    '
+S2 = f"{S1}    "
+
 def test_shebang():
     uut = Generator("cli_package", {})
     text = uut.shebang()
@@ -1188,35 +1191,38 @@ def test_op_body_arguments():
     ["names", "expected"],
     [
         pytest.param(None, "", id="None"),
-        pytest.param(PaginationNames(), "page_info = _r.PageParams(max_count=_max_count)", id="empty"),
+        pytest.param(PaginationNames(), f"page_info = _r.PageParams({S2}max_count=_max_count,{S1})", id="empty"),
         pytest.param(
             PaginationNames(page_size="fooBar"),
-            'page_info = _r.PageParams(max_count=_max_count, page_size_name="fooBar", page_size_value=foo_bar)',
+            f'page_info = _r.PageParams({S2}max_count=_max_count,{S2}page_size_name="fooBar",'
+            f'{S2}page_size_value=foo_bar,{S1})',
             id="page_size",
         ),
         pytest.param(
             PaginationNames(page_start="snaFoo"),
-            'page_info = _r.PageParams(max_count=_max_count, page_start_name="snaFoo", page_start_value=sna_foo)',
+            f'page_info = _r.PageParams({S2}max_count=_max_count,{S2}page_start_name="snaFoo",'
+            f'{S2}page_start_value=sna_foo,{S1})',
             id="page_start",
         ),
         pytest.param(
             PaginationNames(item_start="eastWest"),
-            'page_info = _r.PageParams(max_count=_max_count, item_start_name="eastWest", item_start_value=east_west)',
+            f'page_info = _r.PageParams({S2}max_count=_max_count,{S2}item_start_name="eastWest",'
+            f'{S2}item_start_value=east_west,{S1})',
             id="item_start",
         ),
         pytest.param(
             PaginationNames(items_property="northSouth"),
-            'page_info = _r.PageParams(max_count=_max_count, item_property_name="northSouth")',
+            f'page_info = _r.PageParams({S2}max_count=_max_count,{S2}item_property_name="northSouth",{S1})',
             id="items_property",
         ),
         pytest.param(
             PaginationNames(next_header="upDown"),
-            'page_info = _r.PageParams(max_count=_max_count, next_header_name="upDown")',
+            f'page_info = _r.PageParams({S2}max_count=_max_count,{S2}next_header_name="upDown",{S1})',
             id="next_header",
         ),
         pytest.param(
             PaginationNames(next_property="leftRight"),
-            'page_info = _r.PageParams(max_count=_max_count, next_property_name="leftRight")',
+            f'page_info = _r.PageParams({S2}max_count=_max_count,{S2}next_property_name="leftRight",{S1})',
             id="next_property",
         ),
     ]
@@ -1390,7 +1396,10 @@ def test_function_definition_paged():
     assert '_max_count: _a.MaxCountOption' in text
 
     # double check a few important body differences
-    assert 'page_info = _r.PageParams(max_count=_max_count, page_size_name="limit", page_size_value=limit)' in text
+    assert (
+        f'page_info = _r.PageParams({S2}max_count=_max_count,{S2}page_size_name="limit",{S2}page_size_value=limit,{S1})'
+        in text
+    )
     assert 'data = _r.depaginate(page_info, url, headers=headers, params=params, timemout=_api_timeout)' in text
 
 


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

In many cases, the generated code for `PageParams` instantiation was excessively long. Although not harmful or as long as some of the other lines, the code is more understandable when split into multiple lines.


## CHANGES
<!-- Please explain at a high-level the changes. -->

Updated the code that generates the `PageParams` instantiations, and regenerate example code.


<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->