### PR TITLE
Include the tests/cli_gen in the wheel so they can be copied

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,10 @@ version = "0.4.0"
 description = "OpenAPI specification tools for analyzing, updating, and generating a CLI."
 authors = ["Rick Porter <rickwporter@gmail.com>"]
 readme = "README.md"
+# NOTE: including all cli_gen tests... some are copied when generating code with tests
+include = [
+    { path = "tests/cli_gen", format = ["sdist", "wheel"] },
+]
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Include the `tests/cli_gen` in the wheel so they can be used for generating tests.

## CHANGES
<!-- Please explain at a high-level the changes. -->

Update `pyproject.toml` to add copy the tests into the wheel.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->