### PR TITLE
Fix PEP naming for classes -- when two back-to-back special characters

### DIFF
--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -195,7 +195,7 @@ if __name__ == "__main__":
 
     def class_name(self, s: str) -> str:
         """Get the class name for provided string."""
-        value = to_camel_case(replace_special(s))
+        value = to_camel_case(replace_special(s)).replace("_", "")
         return value[0].upper() + value[1:]
 
     def function_name(self, s: str) -> str:

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -245,6 +245,7 @@ def test_schema_to_type(schema, fmt, expected):
         pytest.param("any", "Any", id="any"),
         pytest.param("input", "Input", id="input"),
         pytest.param("list", "List", id="list"),
+        pytest.param("@foo@&bar", "FooBar", id="pep-underscore"),
     ]
 )
 def test_class_name(proposed, expected):


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Fix issue with class names were the input has multiple special characters in a row -- end up with `_` in the name. This change makes the names PEP compliant.

## CHANGES
<!-- Please explain at a high-level the changes. -->

Strip extra `_` out of class names.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->