### PR TITLE
Remove logger ambiguity

### DIFF
--- a/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/_logging.py
+++ b/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/_logging.py
@@ -19,10 +19,10 @@ class LogLevel(str, Enum):
     DEBUG = "debug"
 
 
-def logger(name: Optional[str] = LOG_CLASS) -> logging.Logger:
+def get_logger(name: Optional[str] = LOG_CLASS) -> logging.Logger:
     return logging.getLogger(name=name)
 
 
-def init_logging(level: LogLevel, name: Optional[str] = LOG_CLASS):
+def init_logging(level: LogLevel, name: Optional[str] = LOG_CLASS) -> logging.Logger:
     logging.basicConfig(format=LOG_FORMAT, datefmt=LOG_DATE_FMT)
-    logger(name).setLevel(level.upper())
+    return get_logger(name).setLevel(level.upper())

--- a/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/_requests.py
+++ b/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/_requests.py
@@ -19,7 +19,7 @@ from typing import Optional
 import requests
 import yaml
 
-from cloudtruth_gen_cli._logging import logger
+from cloudtruth_gen_cli._logging import get_logger
 
 GET = "GET"
 EXTENSION_MAP = {
@@ -62,7 +62,7 @@ EXTENSION_MAP = {
     "application/vnd.mozilla.xul+xml": "xml",
 }
 
-logger = logger()
+logger = get_logger()
 
 
 @dataclass

--- a/examples/github/github_gen_cli/_logging.py
+++ b/examples/github/github_gen_cli/_logging.py
@@ -19,10 +19,10 @@ class LogLevel(str, Enum):
     DEBUG = "debug"
 
 
-def logger(name: Optional[str] = LOG_CLASS) -> logging.Logger:
+def get_logger(name: Optional[str] = LOG_CLASS) -> logging.Logger:
     return logging.getLogger(name=name)
 
 
-def init_logging(level: LogLevel, name: Optional[str] = LOG_CLASS):
+def init_logging(level: LogLevel, name: Optional[str] = LOG_CLASS) -> logging.Logger:
     logging.basicConfig(format=LOG_FORMAT, datefmt=LOG_DATE_FMT)
-    logger(name).setLevel(level.upper())
+    return get_logger(name).setLevel(level.upper())

--- a/examples/github/github_gen_cli/_requests.py
+++ b/examples/github/github_gen_cli/_requests.py
@@ -19,7 +19,7 @@ from typing import Optional
 import requests
 import yaml
 
-from github_gen_cli._logging import logger
+from github_gen_cli._logging import get_logger
 
 GET = "GET"
 EXTENSION_MAP = {
@@ -62,7 +62,7 @@ EXTENSION_MAP = {
     "application/vnd.mozilla.xul+xml": "xml",
 }
 
-logger = logger()
+logger = get_logger()
 
 
 @dataclass

--- a/examples/pets-cli/pets_cli/_logging.py
+++ b/examples/pets-cli/pets_cli/_logging.py
@@ -19,10 +19,10 @@ class LogLevel(str, Enum):
     DEBUG = "debug"
 
 
-def logger(name: Optional[str] = LOG_CLASS) -> logging.Logger:
+def get_logger(name: Optional[str] = LOG_CLASS) -> logging.Logger:
     return logging.getLogger(name=name)
 
 
-def init_logging(level: LogLevel, name: Optional[str] = LOG_CLASS):
+def init_logging(level: LogLevel, name: Optional[str] = LOG_CLASS) -> logging.Logger:
     logging.basicConfig(format=LOG_FORMAT, datefmt=LOG_DATE_FMT)
-    logger(name).setLevel(level.upper())
+    return get_logger(name).setLevel(level.upper())

--- a/examples/pets-cli/pets_cli/_requests.py
+++ b/examples/pets-cli/pets_cli/_requests.py
@@ -19,7 +19,7 @@ from typing import Optional
 import requests
 import yaml
 
-from pets_cli._logging import logger
+from pets_cli._logging import get_logger
 
 GET = "GET"
 EXTENSION_MAP = {
@@ -62,7 +62,7 @@ EXTENSION_MAP = {
     "application/vnd.mozilla.xul+xml": "xml",
 }
 
-logger = logger()
+logger = get_logger()
 
 
 @dataclass

--- a/examples/pets-cli/tests/test_logging.py
+++ b/examples/pets-cli/tests/test_logging.py
@@ -8,15 +8,15 @@ import pytest
 
 from pets_cli._logging import LOG_CLASS
 from pets_cli._logging import LogLevel
+from pets_cli._logging import get_logger
 from pets_cli._logging import init_logging
-from pets_cli._logging import logger
 
 
 def test_get_logger() -> None:
-    log = logger()
+    log = get_logger()
     assert log.name == LOG_CLASS
 
-    req_logger = logger("requests")
+    req_logger = get_logger("requests")
     assert req_logger.name == "requests"
 
 
@@ -32,6 +32,6 @@ def test_get_logger() -> None:
 )
 def test_init_logging(level: LogLevel, expected: int) -> None:
     init_logging(level)
-    log = logger()
+    log = get_logger()
     assert LOG_CLASS == log.name
     assert expected == log.level

--- a/openapi_spec_tools/cli_gen/_logging.py
+++ b/openapi_spec_tools/cli_gen/_logging.py
@@ -15,10 +15,10 @@ class LogLevel(str, Enum):
     DEBUG = "debug"
 
 
-def logger(name: Optional[str] = LOG_CLASS) -> logging.Logger:
+def get_logger(name: Optional[str] = LOG_CLASS) -> logging.Logger:
     return logging.getLogger(name=name)
 
 
-def init_logging(level: LogLevel, name: Optional[str] = LOG_CLASS):
+def init_logging(level: LogLevel, name: Optional[str] = LOG_CLASS) -> logging.Logger:
     logging.basicConfig(format=LOG_FORMAT, datefmt=LOG_DATE_FMT)
-    logger(name).setLevel(level.upper())
+    return get_logger(name).setLevel(level.upper())

--- a/openapi_spec_tools/cli_gen/_requests.py
+++ b/openapi_spec_tools/cli_gen/_requests.py
@@ -15,7 +15,7 @@ from typing import Optional
 import requests
 import yaml
 
-from openapi_spec_tools.cli_gen._logging import logger
+from openapi_spec_tools.cli_gen._logging import get_logger
 
 GET = "GET"
 EXTENSION_MAP = {
@@ -58,7 +58,7 @@ EXTENSION_MAP = {
     "application/vnd.mozilla.xul+xml": "xml",
 }
 
-logger = logger()
+logger = get_logger()
 
 
 @dataclass

--- a/openapi_spec_tools/cli_gen/cli.py
+++ b/openapi_spec_tools/cli_gen/cli.py
@@ -16,8 +16,8 @@ from rich.console import Console
 from rich.table import Table
 
 from openapi_spec_tools.cli_gen._arguments import LogLevelOption
+from openapi_spec_tools.cli_gen._logging import get_logger
 from openapi_spec_tools.cli_gen._logging import init_logging
-from openapi_spec_tools.cli_gen._logging import logger
 from openapi_spec_tools.cli_gen._tree import TreeDisplay
 from openapi_spec_tools.cli_gen._tree import create_tree_table
 from openapi_spec_tools.cli_gen.constants import GENERATOR_LOG_CLASS
@@ -65,7 +65,7 @@ def open_oas_with_error_handling(filename: str) -> Any:
         starttime = datetime.now()
         data = open_oas(filename)
         delta = datetime.now() - starttime
-        logger(GENERATOR_LOG_CLASS).info(f"Opening {filename} took {delta.total_seconds()} seconds")
+        get_logger(GENERATOR_LOG_CLASS).info(f"Opening {filename} took {delta.total_seconds()} seconds")
         return data
     except FileNotFoundError:
         message = f"failed to find {filename}"
@@ -85,7 +85,7 @@ def open_layout_with_error_handling(filename: str) -> Any:
         starttime = datetime.now()
         data = open_layout(filename)
         delta = datetime.now() - starttime
-        logger(GENERATOR_LOG_CLASS).info(f"Opening {filename} took {delta.total_seconds()} seconds")
+        get_logger(GENERATOR_LOG_CLASS).info(f"Opening {filename} took {delta.total_seconds()} seconds")
         return data
     except FileNotFoundError:
         message = f"failed to find {filename}"
@@ -105,7 +105,7 @@ def layout_tree_with_error_handling(filename: str, start: str) -> LayoutNode:
         starttime = datetime.now()
         tree = file_to_tree(filename, start)
         delta = datetime.now() - starttime
-        logger(GENERATOR_LOG_CLASS).info(f"Parsing {filename} into tree took {delta.total_seconds()} seconds")
+        get_logger(GENERATOR_LOG_CLASS).info(f"Parsing {filename} into tree took {delta.total_seconds()} seconds")
         return tree
     except FileNotFoundError:
         message = f"failed to find {filename}"

--- a/openapi_spec_tools/cli_gen/files.py
+++ b/openapi_spec_tools/cli_gen/files.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from openapi_spec_tools.cli_gen._logging import logger
+from openapi_spec_tools.cli_gen._logging import get_logger
 from openapi_spec_tools.cli_gen._tree import TreeField
 from openapi_spec_tools.cli_gen._tree import TreeNode
 from openapi_spec_tools.cli_gen.constants import GENERATOR_LOG_CLASS
@@ -44,7 +44,7 @@ DEFAULT_COPYRIGHT = f"""\
 """
 
 _copyright = DEFAULT_COPYRIGHT
-logger = logger(GENERATOR_LOG_CLASS)
+logger = get_logger(GENERATOR_LOG_CLASS)
 
 
 def set_copyright(copyright: str = DEFAULT_COPYRIGHT) -> None:

--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 import yaml
 
-from openapi_spec_tools.cli_gen._logging import logger
+from openapi_spec_tools.cli_gen._logging import get_logger
 from openapi_spec_tools.cli_gen._tree import TreeField
 from openapi_spec_tools.cli_gen.constants import GENERATOR_LOG_CLASS
 from openapi_spec_tools.cli_gen.layout_types import LayoutNode
@@ -86,7 +86,7 @@ class Generator:
             ContentType.APP_JSON,
         ]
         self.max_help_length = 120
-        self.logger = logger(GENERATOR_LOG_CLASS)
+        self.logger = get_logger(GENERATOR_LOG_CLASS)
 
     def shebang(self) -> str:
         """Get the shebang line that goes at the top of each file."""

--- a/tests/cli_gen/test_logging.py
+++ b/tests/cli_gen/test_logging.py
@@ -4,15 +4,15 @@ import pytest
 
 from openapi_spec_tools.cli_gen._logging import LOG_CLASS
 from openapi_spec_tools.cli_gen._logging import LogLevel
+from openapi_spec_tools.cli_gen._logging import get_logger
 from openapi_spec_tools.cli_gen._logging import init_logging
-from openapi_spec_tools.cli_gen._logging import logger
 
 
 def test_get_logger() -> None:
-    log = logger()
+    log = get_logger()
     assert log.name == LOG_CLASS
 
-    req_logger = logger("requests")
+    req_logger = get_logger("requests")
     assert req_logger.name == "requests"
 
 
@@ -28,6 +28,6 @@ def test_get_logger() -> None:
 )
 def test_init_logging(level: LogLevel, expected: int) -> None:
     init_logging(level)
-    log = logger()
+    log = get_logger()
     assert LOG_CLASS == log.name
     assert expected == log.level


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

In several places, there was ambiguity between the `logger` function and the `logger` variable. This changes the function name to `get_logger()` to avoid the ambiguity.

## CHANGES
<!-- Please explain at a high-level the changes. -->

Change `_logging.logger()` to `_logging.get_logger()` to avoid ambiguity.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->