### PR TITLE
Fix issue caused by improved 'commands' help

### DIFF
--- a/tests/cli_gen/test_main.py
+++ b/tests/cli_gen/test_main.py
@@ -15,7 +15,8 @@ def test_main_help():
     help = to_ascii(result.stdout)
     # assert "--install-completion" in help
     # assert "--show-completion" in help
-    assert "Display commands tree for sub-commands" in help
+    # NOTE: this is not updated with the "actual" parent name, so it is shorter than would be nice
+    assert "Display commands tree for " in help
 
 
 def test_main_commands():


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

When the `commands` help was updated, the `test_main.py` needed to get updated to avoid failure due to the "parent" name now being included in the help string.

## CHANGES
<!-- Please explain at a high-level the changes. -->

Shortened the search string to avoid the specialization.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->