### PR TITLE
Fix issue with multi-type enums

### DIFF
--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -425,7 +425,17 @@ if __name__ == "__main__":
         if ref:
             name = self.short_reference_name(ref)
             schema = self.get_model(ref)
-        return self.model_settable_properties(name, schema)
+
+        # attempt to simplify enum types to a single type to something that matches
+        properties = self.model_settable_properties(name, schema)
+        for prop_data in properties.values():
+            enum_values = prop_data.get(OasField.ENUM)
+            schema_type = prop_data.get(OasField.TYPE)
+            if enum_values and isinstance(schema_type, list):
+                schema_list = self.enum_find_schema(schema_type, enum_values)
+                prop_data[OasField.TYPE.value] = schema_list[0]
+
+        return properties
 
     def short_reference_name(self, full_name: str) -> str:
         """Transform the '#/components/schemas/Xxx' to 'Xxx'."""
@@ -683,6 +693,9 @@ if __name__ == "__main__":
 
         schema_type = prop.get(OasField.TYPE)
         nullable = isinstance(schema_type, list) and any(nt in schema_type for nt in NULL_TYPES)
+        enum_values = prop.get(OasField.ENUM)
+        if enum_values and isinstance(schema_type, list):
+            schema_type = self.enum_find_schema(schema_type, enum_values)
         schema_type = self.simplify_type(schema_type)
         if schema_type in COLLECTIONS.keys():
             prop.update(prop.pop(OasField.ITEMS, {}))
@@ -952,6 +965,28 @@ if __name__ == "__main__":
             pass
 
         return True
+
+    def enum_values_match_type(self, enum_type: str, values: list[Any]) -> bool:
+        """Check if all values align with the proposed enum_type."""
+        if enum_type in ('str', 'string'):
+            return True  # everything can be expressed as a string
+
+        supported = str
+        if enum_type == 'integer':
+            supported = int
+        elif enum_type in ('numeric', 'number'):
+            supported = (float, int)
+        elif enum_type == 'boolean':
+            supported = bool
+
+        return all(isinstance(v, supported) for v in values)
+
+    def enum_find_schema(self, schema_types: list[str], enum_values: list[Any]) -> list[str]:
+        """Resolve to single schema type (if possible)."""
+        # take the first schema_type item where the values match the type
+        return [
+            enum_type for enum_type in schema_types if self.enum_values_match_type(enum_type, enum_values)
+        ]
 
     def enum_declaration(self, name: str, enum_type: str, values: list[Any]) -> str:
         """Turn data into an enum declation."""

--- a/tests/assets/misc.yaml
+++ b/tests/assets/misc.yaml
@@ -92,7 +92,7 @@ paths:
           in: query
           x-deprecated: last-release
           schema:
-            type: str
+            type: string
             enum:
             - Mon
             - Tue
@@ -112,7 +112,7 @@ paths:
         - name: enumWithDefault
           in: query
           schema:
-            type: str
+            type: string
             enum:
             - This
             - That
@@ -149,6 +149,17 @@ paths:
           in: header
           schema:
             $ref: '#/components/schemas/Color'
+        - name: crazyEnum
+          in: query
+          schema:
+            type:
+            - numeric
+            - string
+            enum:
+            - 1.0
+            - 3.14159
+            - pi
+          default: 1.0
       requestBody:
         content:
           application/json:
@@ -291,6 +302,15 @@ components:
             description: enum buried in all-of
           owner:
             $ref: '#/components/schemas/Owner'
+          inconsistent:
+            type:
+            - integer
+            - string
+            enum:
+            - 1
+            - 2
+            - infinity-and-beyond
+            default: 2
 
     Pets:
       type: array
@@ -643,6 +663,7 @@ components:
       - $ref: '#/components/schemas/MissingItemsModel'
       type: object
     DayOfWeek:
+      type: string
       enum:
         - FRIDAY
         - friday

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -197,7 +197,9 @@ def test_op_param_formation():
         params["addr.state"] = addr_state
     params["addr.zipCode"] = addr_zip_code
     if favorite_day is not None:
-        params["favoriteDay"] = favorite_day\
+        params["favoriteDay"] = favorite_day
+    if crazy_enum is not None:
+        params["crazyEnum"] = crazy_enum\
 """
     text = uut.op_param_formation(properties)
     assert expected == text
@@ -450,6 +452,8 @@ def test_op_body_formation():
     assert 'body["gone"] = gone' in text
     assert 'if best_day is not None' in text
     assert 'body["bestDay"] = best_day' in text
+    assert 'if inconsistent is not None' in text
+    assert 'body["inconsistent"] = inconsistent' in text
 
     # this is for the sub-object -- just check the infra and a couple properties
     assert 'owner = {}' in text
@@ -569,6 +573,10 @@ def test_op_query_arguments():
         'case_sensitive=True, help="")] = None'
         in text
     )
+    assert (
+        'crazy_enum: Annotated[CrazyEnum, typer.Option(case_sensitive=False, help="")] = "1.0"'
+        in text
+    )
 
     # make sure path params not included
     assert 'num_feet: Annotated' not in text
@@ -593,6 +601,22 @@ def test_model_is_complex(reference, expected):
     model = uut.get_model(f"#/components/schemas/{reference}")
     assert expected == uut.model_is_complex(model)
 
+
+@pytest.mark.parametrize(
+    ["enum_type", "values", "expected"],
+    [
+        pytest.param('string', [1, "*"], True, id="str-match"),
+        pytest.param('integer', [-1, 0, 1, 2, 3], True, id="int-match"),
+        pytest.param('integer', [-1, 0.1, 1, 2, 3], False, id="int-diff"),
+        pytest.param('numeric', [-1, 0, 1, 2, 3.14159], True, id="float-match"),
+        pytest.param('numeric', [-1, 0.1, 1, 2, 3, '*'], False, id="float-diff"),
+        pytest.param('boolean', [True, False, True, True], True, id='bool-match'),
+        pytest.param('boolean', [False, 0, True], False, id="bool-diff")
+    ]
+)
+def test_enum_values_match_type(enum_type, values, expected):
+    uut = Generator("cli_package", {})
+    assert expected == uut.enum_values_match_type(enum_type, values)
 
 SIMPLE_ENUM = """\
 class Simple(str, Enum):  # noqa: F811
@@ -1178,6 +1202,10 @@ def test_op_body_arguments():
     assert (
         'best_day: Annotated[Optional[DayOfWeek], typer.Option(show_default=False, '
         'case_sensitive=True, help="enum buried in all-of")] = None'
+        in text
+    )
+    assert (
+        'inconsistent: Annotated[Optional[Inconsistent], typer.Option(case_sensitive=False)] = "2"'
         in text
     )
 


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

The OAS can contain enumerations with multiple types, but Python infrastructure does NOT handle that well.

For example (query parameter):
```yaml
    - name: divisor
      in: query
      schema:
        type:
        - numeric
        - string
        enum:
        - 1.0
        - 3.14159
        - pi
      default: 1.0
```

Since `pi` cannot be expressed as a float (as a CLI argument), the Python enum must be of type `str`.

## CHANGES
<!-- Please explain at a high-level the changes. -->

Update the functions that convert body/parameter to settable properties to limit to a single type which can be used to express all enum values. By setting it during the conversion, the logic is already in place to handle proper enum property/value conversion.


<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->