### PR TITLE
Fixes for enums and default values

### DIFF
--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -433,7 +433,11 @@ if __name__ == "__main__":
             schema_type = prop_data.get(OasField.TYPE)
             if enum_values and isinstance(schema_type, list):
                 schema_list = self.enum_find_schema(schema_type, enum_values)
-                prop_data[OasField.TYPE.value] = schema_list[0]
+                schema_type = schema_list[0]
+                prop_data[OasField.TYPE.value] = schema_type
+            # make sure the enumeration and default values align with the type
+            if enum_values and schema_type == "string":
+                self.enum_stringify(prop_data)
 
         return properties
 
@@ -617,15 +621,14 @@ if __name__ == "__main__":
                 arg_type = f"Optional[{arg_type}]"
                 arg_default = " = None"
                 typer_args.append('show_default=False')
+            elif collection and not isinstance(schema_default, list):
+                arg_default = f" = [{maybe_quoted(schema_default)}]"
             else:
                 arg_default = f" = {maybe_quoted(schema_default)}"
         is_enum = bool(param.get(OasField.ENUM))
         if is_enum:
             case_sensitive = is_case_sensitive(param.get(OasField.ENUM))
             typer_args.append(f"case_sensitive={case_sensitive}")
-            enum_type = param.get(OasField.TYPE)
-            if enum_type == "string" and schema_default is not None:
-                arg_default = f" = {quoted(str(schema_default))}"
         if deprected or x_deprecated:
             typer_args.append("hidden=True")
         typer_args.append(f'help="{simple_escape(description)}"')
@@ -692,17 +695,33 @@ if __name__ == "__main__":
             self.logger.warning(f"Grabbing anyOf[0] item from {shallow(any_of[0])}")
             prop.update(any_of[0])
 
+        nullable = False
         schema_type = prop.get(OasField.TYPE)
-        nullable = isinstance(schema_type, list) and any(nt in schema_type for nt in NULL_TYPES)
+        if isinstance(schema_type, list):
+            nullable = any(nt in schema_type for nt in NULL_TYPES)
+            schema_list = [v for v in schema_type if v not in NULL_TYPES]
+            nullable = schema_type != schema_list
+            if len(schema_list) == 1:
+                schema_type = schema_list[0]
+            else:
+                schema_type = schema_list
+            prop[OasField.TYPE.value] = schema_type
+
+        if isinstance(schema_type, str) and schema_type in COLLECTIONS.keys():
+            items = prop.pop(OasField.ITEMS, {})
+            prop.update(items)
+            prop[OasField.X_COLLECT.value] = schema_type
+            schema_type = items.get(OasField.TYPE)
+
         enum_values = prop.get(OasField.ENUM)
         if enum_values and isinstance(schema_type, list):
-            schema_type = self.enum_find_schema(schema_type, enum_values)
-        schema_type = self.simplify_type(schema_type)
-        if schema_type in COLLECTIONS.keys():
-            prop.update(prop.pop(OasField.ITEMS, {}))
-            prop[OasField.X_COLLECT.value] = schema_type
-        elif schema_type:
+            schema_list = self.enum_find_schema(schema_type, enum_values)
+            schema_type = schema_list[0]
             prop[OasField.TYPE.value] = schema_type
+
+        # make sure the enumeration and default values align with the type
+        if enum_values and schema_type == "string":
+            self.enum_stringify(prop)
 
         schema = self.simplify_type(prop)
         if schema:
@@ -746,19 +765,23 @@ if __name__ == "__main__":
         args = []
         for prop_name, prop_data in body_params.items():
             py_type = self.get_property_pytype(prop_name, prop_data)
+            var_name = self.variable_name(prop_name)
+            collection = COLLECTIONS.get(prop_data.get(OasField.X_COLLECT, ""))
+            schema_default = prop_data.get(OasField.DEFAULT)
 
             t_args = []
             if prop_name.lower() in RESERVED:
                 # when the variable name is changed to avoid conflict with builtins, add an option with "original" name
                 t_args.append(quoted(self.option_name(prop_name)))
-            def_val = prop_data.get(OasField.DEFAULT)
-            if def_val is None:
+            if schema_default is None:
                 t_args.append("show_default=False")
+                def_val = None
+            elif collection and not isinstance(schema_default, list):
+                def_val = [schema_default]
+            else:
+                def_val = schema_default
             is_enum = bool(prop_data.get(OasField.ENUM))
             if is_enum:
-                if prop_data.get(OasField.TYPE) == "string" and def_val is not None:
-                    # convert the default value to a string so it gets quoted
-                    def_val = str(def_val)
                 case_sensitive = is_case_sensitive(prop_data.get(OasField.ENUM))
                 t_args.append(f"case_sensitive={case_sensitive}")
             deprected = prop_data.get(OasField.DEPRECATED, False)
@@ -769,7 +792,7 @@ if __name__ == "__main__":
             if help:
                 t_args.append(f"help={quoted(simple_escape(help))}")
             t_decl = f"typer.Option({', '.join(t_args)})"
-            arg = f"{self.variable_name(prop_name)}: Annotated[{py_type}, {t_decl}] = {maybe_quoted(def_val)}"
+            arg = f"{var_name}: Annotated[{py_type}, {t_decl}] = {maybe_quoted(def_val)}"
             args.append(arg)
 
         return args
@@ -988,6 +1011,22 @@ if __name__ == "__main__":
         return [
             enum_type for enum_type in schema_types if self.enum_values_match_type(enum_type, enum_values)
         ]
+
+    def enum_stringify(self, schema: dict[str, Any]) -> None:
+        """Update the schema to have string values for enum and default values."""
+        enum_values = schema.get(OasField.ENUM)
+        if isinstance(enum_values, list):
+            enum_values = [str(v) for v in enum_values]
+        schema[OasField.ENUM.value] = enum_values
+
+        def_val = schema.get(OasField.DEFAULT)
+        if isinstance(def_val, list):
+            def_val = [str(v) for v in def_val]
+        elif def_val is not None:
+            def_val = str(def_val)
+        schema[OasField.DEFAULT.value] = def_val
+
+        return
 
     def enum_declaration(self, name: str, enum_type: str, values: list[Any]) -> str:
         """Turn data into an enum declation."""

--- a/tests/assets/misc.yaml
+++ b/tests/assets/misc.yaml
@@ -160,6 +160,33 @@ paths:
             - 3.14159
             - pi
           default: 1.0
+        - name: listEnumDefList
+          in: query
+          schema:
+            type: array
+            items:
+              type:
+              - integer
+              - string
+              enum:
+              - '*'
+              - 1
+              - 8
+            default:
+            - 1
+            - 8 
+        - name: listIntEnum
+          in: query
+          schema:
+            type: array
+            items:
+              type:
+              - integer
+              enum:
+              - 8
+              - 6
+              - 7
+            default: 7
       requestBody:
         content:
           application/json:
@@ -311,6 +338,18 @@ components:
             - 2
             - infinity-and-beyond
             default: 2
+          nonListDef:
+            type: array
+            items:
+              type:
+              - numeric
+              - string
+              enum:
+              - 0
+              - 1.1
+              - pi
+              - inf
+            default: 1.1
 
     Pets:
       type: array

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from pathlib import Path
 
 import pytest
@@ -22,6 +23,7 @@ SCHEMA = "schema"
 ANY_OF = "anyOf"
 ONE_OF = "oneOf"
 ITEMS = "items"
+DEF = "default"
 
 S1 = '\n    '
 S2 = f"{S1}    "
@@ -199,7 +201,11 @@ def test_op_param_formation():
     if favorite_day is not None:
         params["favoriteDay"] = favorite_day
     if crazy_enum is not None:
-        params["crazyEnum"] = crazy_enum\
+        params["crazyEnum"] = crazy_enum
+    if list_enum_def_list is not None:
+        params["listEnumDefList"] = list_enum_def_list
+    if list_int_enum is not None:
+        params["listIntEnum"] = list_int_enum\
 """
     text = uut.op_param_formation(properties)
     assert expected == text
@@ -577,6 +583,15 @@ def test_op_query_arguments():
         'crazy_enum: Annotated[CrazyEnum, typer.Option(case_sensitive=False, help="")] = "1.0"'
         in text
     )
+    assert (
+        'list_enum_def_list: Annotated[list[ListEnumDefList], typer.Option(case_sensitive=False, help="")] '
+        "= ['1', '8']"
+        in text
+    )
+    assert (
+        'list_int_enum: Annotated[list[ListIntEnum], typer.Option(case_sensitive=False, help="")] = [7]'
+        in text
+    )
 
     # make sure path params not included
     assert 'num_feet: Annotated' not in text
@@ -677,7 +692,8 @@ FOOBAR_PARAM = {TYPE: "string", ENUM: ["aOrB", "b_or_C", "-minus"], "name": "foo
 NUMBER_PARAM = {TYPE: "integer", ENUM: [12, 37, 11], "name": "simple-number"}
 MIXED_PARAM = {TYPE: "string", ENUM: ["a", 1, True, "b"], "name": "mixed-values"}
 INT_STR_PARAM = {TYPE: "string", ENUM: ["10", "10.1"], "name": "int-strings"}
-
+SIMPLE_PROP = deepcopy(SIMPLE_PARAM)
+SIMPLE_PROP[DEF] = None
 
 @pytest.mark.parametrize(
     ["name", "enum_type", "values", "expected"],
@@ -794,7 +810,7 @@ def test_enum_definitions(path_params, query_params, body_params, expected):
     ["parameter", "expected"],
     [
         pytest.param({}, {}, id="empty"),
-        pytest.param(SIMPLE_PARAM, SIMPLE_PARAM, id="simple"),
+        pytest.param(SIMPLE_PARAM, SIMPLE_PROP, id="simple"),
         pytest.param(
             {ONE_OF: [{TYPE: "foo"}, {TYPE: "array", ITEMS: {TYPE: "foo"}}]},
             {TYPE: "foo", COLLECT: "array"},
@@ -815,6 +831,30 @@ def test_enum_definitions(path_params, query_params, body_params, expected):
             {TYPE: "sna", COLLECT: "array"},
             id="anyOf"
         ),
+        pytest.param(
+            # enum and default values converted to strings
+            {TYPE: "array", ITEMS: {ENUM: ['*', 0], DEF: 0, TYPE: 'string'}},
+            {TYPE: "string", COLLECT: "array", ENUM: ['*', '0'], DEF: '0'},
+            id="enum-str-list",
+        ),
+        pytest.param(
+            # enum and default values stay as integers
+            {TYPE: "array", ITEMS: {TYPE: "integer", ENUM: [1, 5, 9], DEF: 5}},
+            {TYPE: "integer", COLLECT: "array", ENUM: [1, 5, 9], DEF: 5},
+            id="enum-int-list",
+        ),
+        pytest.param(
+            # multiple types converted to string for compatability, and enum/default values converted
+            {TYPE: ["integer", "string"], ENUM: ['*', 1, 3], DEF: 1},
+            {TYPE: "string", ENUM: ['*', '1', '3'], DEF: '1'},
+            id="enum-multi-type",
+        ),
+        pytest.param(
+            # default value list converted to strings
+            {TYPE: "array", ITEMS: {TYPE: ["integer", "string"], ENUM: ["-inf", "pi", 3], DEF: ["pi", 3]}},
+            {TYPE: "string", ENUM: ["-inf", "pi", "3"], COLLECT: "array", DEF: ["pi", "3"]},
+            id="enum-list-default"
+        )
     ],
 )
 def test_param_to_property(parameter, expected):
@@ -1206,6 +1246,10 @@ def test_op_body_arguments():
     )
     assert (
         'inconsistent: Annotated[Optional[Inconsistent], typer.Option(case_sensitive=False)] = "2"'
+        in text
+    )
+    assert (
+        'non_list_def: Annotated[Optional[list[NonListDef]], typer.Option(case_sensitive=False)] = [\'1.1\']'
         in text
     )
 


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Fix a couple related issues:
1. When enum is a string, property "stringify" the enum and default values
2. When a list property/parameter has a non-list default, turn it into a list

## CHANGES
<!-- Please explain at a high-level the changes. -->

Added `Generator.enum_stringify()` to turn the values into strings. This needs to account for default values that are lists (and deal with individual values instead of just making the list a string). 

In both parameter and property conversion, turn single default values into a list when the param/prop is a list.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->