### PR TITLE
Start 'make all' with 'lint'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ default: help
 
 ###########
 ##@ General
-all: example-gen lint cov wheel ## Complete cycle: generate/lint/test everything
+all: lint example-gen lint cov wheel ## Complete cycle: generate/lint/test everything
 
 # NOTE: due to example sub-projects, clean up all occurrances of these files/directories
 clean: ## Remove build/test artifacts


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Waiting for the examples to build only to find out that the linting is bad wastes time.

## CHANGES
<!-- Please explain at a high-level the changes. -->

Added `lint` to beginning of the dependent job list for the `all` target.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->