### PR TITLE
Use variable name as basis for enum class name

### DIFF
--- a/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/grants.py
+++ b/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/grants.py
@@ -38,7 +38,7 @@ def show_commands(
     return
 
 
-class RoleEnum(str, Enum):  # noqa: F811
+class Role(str, Enum):  # noqa: F811
     OWNER = "OWNER"
     ADMIN = "ADMIN"
     CONTRIB = "CONTRIB"
@@ -49,7 +49,7 @@ class RoleEnum(str, Enum):  # noqa: F811
 def grants_create(
     principal: Annotated[str, typer.Option(show_default=False, help="The URI of a principal for the grant; this must reference a user or group.")] = None,
     scope: Annotated[str, typer.Option(show_default=False, help="The URI of a scope for the grant; this must reference a project or environment.")] = None,
-    role: Annotated[RoleEnum, typer.Option(show_default=False, case_sensitive=False, help="The role that the principal has in the given scope.")] = None,
+    role: Annotated[Role, typer.Option(show_default=False, case_sensitive=False, help="The role that the principal has in the given scope.")] = None,
     _api_host: _a.ApiHostOption = "",
     _api_key: _a.ApiKeyOption = None,
     _api_timeout: _a.ApiTimeoutOption = 5,
@@ -241,7 +241,7 @@ def grants_list(
     return
 
 
-class RoleEnum(str, Enum):  # noqa: F811
+class Role(str, Enum):  # noqa: F811
     OWNER = "OWNER"
     ADMIN = "ADMIN"
     CONTRIB = "CONTRIB"
@@ -253,7 +253,7 @@ def grants_update(
     id: Annotated[str, typer.Argument(show_default=False, help="A unique identifier for the grant.")],
     principal: Annotated[str, typer.Option(show_default=False, help="The URI of a principal for the grant; this must reference a user or group.")] = None,
     scope: Annotated[str, typer.Option(show_default=False, help="The URI of a scope for the grant; this must reference a project or environment.")] = None,
-    role: Annotated[RoleEnum, typer.Option(show_default=False, case_sensitive=False, help="The role that the principal has in the given scope.")] = None,
+    role: Annotated[Role, typer.Option(show_default=False, case_sensitive=False, help="The role that the principal has in the given scope.")] = None,
     _api_host: _a.ApiHostOption = "",
     _api_key: _a.ApiKeyOption = None,
     _api_timeout: _a.ApiTimeoutOption = 5,
@@ -337,7 +337,7 @@ def grants_retrieve(
     return
 
 
-class RoleEnum(str, Enum):  # noqa: F811
+class Role(str, Enum):  # noqa: F811
     OWNER = "OWNER"
     ADMIN = "ADMIN"
     CONTRIB = "CONTRIB"
@@ -349,7 +349,7 @@ def grants_partial_update(
     id: Annotated[str, typer.Argument(show_default=False, help="A unique identifier for the grant.")],
     principal: Annotated[Optional[str], typer.Option(show_default=False, help="The URI of a principal for the grant; this must reference a user or group.")] = None,
     scope: Annotated[Optional[str], typer.Option(show_default=False, help="The URI of a scope for the grant; this must reference a project or environment.")] = None,
-    role: Annotated[Optional[RoleEnum], typer.Option(show_default=False, case_sensitive=False, help="The role that the principal has in the given scope.")] = None,
+    role: Annotated[Optional[Role], typer.Option(show_default=False, case_sensitive=False, help="The role that the principal has in the given scope.")] = None,
     _api_host: _a.ApiHostOption = "",
     _api_key: _a.ApiKeyOption = None,
     _api_timeout: _a.ApiTimeoutOption = 5,

--- a/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/memberships.py
+++ b/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/memberships.py
@@ -38,7 +38,7 @@ def show_commands(
     return
 
 
-class RoleEnum(str, Enum):  # noqa: F811
+class Role(str, Enum):  # noqa: F811
     OWNER = "OWNER"
     ADMIN = "ADMIN"
     CONTRIB = "CONTRIB"
@@ -48,7 +48,7 @@ class RoleEnum(str, Enum):  # noqa: F811
 @app.command("create", short_help="")
 def memberships_create(
     user: Annotated[str, typer.Option(show_default=False, help="The user of the membership.")] = None,
-    role: Annotated[RoleEnum, typer.Option(show_default=False, case_sensitive=False, help="The role that the user has in the organization.")] = None,
+    role: Annotated[Role, typer.Option(show_default=False, case_sensitive=False, help="The role that the user has in the organization.")] = None,
     _api_host: _a.ApiHostOption = "",
     _api_key: _a.ApiKeyOption = None,
     _api_timeout: _a.ApiTimeoutOption = 5,
@@ -177,7 +177,7 @@ def memberships_list(
     return
 
 
-class RoleEnum(str, Enum):  # noqa: F811
+class Role(str, Enum):  # noqa: F811
     OWNER = "OWNER"
     ADMIN = "ADMIN"
     CONTRIB = "CONTRIB"
@@ -189,7 +189,7 @@ def memberships_update(
     id: Annotated[str, typer.Argument(show_default=False, help="A unique identifier for the membership.")],
     user: Annotated[str, typer.Option(show_default=False, help="The user of the membership.")] = None,
     organization: Annotated[str, typer.Option(show_default=False, help="The organization that the user is a member of.")] = None,
-    role: Annotated[RoleEnum, typer.Option(show_default=False, case_sensitive=False, help="The role that the user has in the organization.")] = None,
+    role: Annotated[Role, typer.Option(show_default=False, case_sensitive=False, help="The role that the user has in the organization.")] = None,
     _api_host: _a.ApiHostOption = "",
     _api_key: _a.ApiKeyOption = None,
     _api_timeout: _a.ApiTimeoutOption = 5,
@@ -259,7 +259,7 @@ def memberships_retrieve(
     return
 
 
-class RoleEnum(str, Enum):  # noqa: F811
+class Role(str, Enum):  # noqa: F811
     OWNER = "OWNER"
     ADMIN = "ADMIN"
     CONTRIB = "CONTRIB"
@@ -271,7 +271,7 @@ def memberships_partial_update(
     id: Annotated[str, typer.Argument(show_default=False, help="A unique identifier for the membership.")],
     user: Annotated[Optional[str], typer.Option(show_default=False, help="The user of the membership.")] = None,
     organization: Annotated[Optional[str], typer.Option(show_default=False, help="The organization that the user is a member of.")] = None,
-    role: Annotated[Optional[RoleEnum], typer.Option(show_default=False, case_sensitive=False, help="The role that the user has in the organization.")] = None,
+    role: Annotated[Optional[Role], typer.Option(show_default=False, case_sensitive=False, help="The role that the user has in the organization.")] = None,
     _api_host: _a.ApiHostOption = "",
     _api_key: _a.ApiKeyOption = None,
     _api_timeout: _a.ApiTimeoutOption = 5,

--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -536,7 +536,7 @@ if __name__ == "__main__":
         """
         values = param_data.get(OasField.ENUM)
         if values:
-            name = self.short_reference_name(param_data.get(OasField.REFS, "")) or param_data.get(OasField.NAME)
+            name = param_data.get(OasField.NAME)
             return self.class_name(name)
 
         return self.schema_to_pytype(param_data)
@@ -547,7 +547,7 @@ if __name__ == "__main__":
         Each property potentially has 'type' and 'format' fields.
         """
         if prop_data.get(OasField.ENUM):
-            pytype = self.class_name(prop_data.get(OasField.X_REF) or prop_name)
+            pytype = self.class_name(prop_name)
         else:
             pytype = self.schema_to_pytype(prop_data)
             if not pytype:
@@ -1065,7 +1065,7 @@ if __name__ == "__main__":
             if not values:
                 continue
 
-            e_name = self.short_reference_name(param_data.get(OasField.REFS, "")) or param_data.get(OasField.NAME)
+            e_name = param_data.get(OasField.NAME)
             e_type = self.schema_to_pytype(param_data) or 'str'
             enums[self.class_name(e_name)] = (e_type, values)
 
@@ -1073,9 +1073,8 @@ if __name__ == "__main__":
             values = prop.get(OasField.ENUM)
             if not values:
                 continue
-            e_name = prop.get(OasField.X_REF) or name
             e_type = self.schema_to_pytype(prop) or 'str'
-            enums[self.class_name(e_name)] = (e_type, values)
+            enums[self.class_name(name)] = (e_type, values)
 
         if not enums:
             return ""

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -367,7 +367,7 @@ def test_simplify_type(schema, expected):
         pytest.param({TYPE: "string", ENUM: ["a", "b"], "name": "sna_foo"}, "SnaFoo", id="unref-enum"),
         pytest.param(
             {TYPE: "string", ENUM: ["a", "b"], "$ref": "#/comp/Schema/FooBar", "name": "sna_foo"},
-            "FooBar",
+            "SnaFoo",
             id="ref-enum",
         ),
     ],
@@ -400,7 +400,7 @@ def test_get_parameter_pytype(param_data, expected):
         pytest.param(
             "foo",
             {TYPE: "string", REQUIRED: True, ENUM: ["a", "b"], "x-reference": "east_west"},
-            "EastWest",
+            "Foo",
             id="named-enum",
         ),
         pytest.param(
@@ -554,7 +554,8 @@ def test_op_query_arguments():
         in text
     )
     assert (
-        'param_with_enum_ref: Annotated[Species, typer.Option(case_sensitive=False, help="Species type")] = "frog"'
+        'param_with_enum_ref: Annotated[ParamWithEnumRef, typer.Option(case_sensitive=False, '
+        'help="Species type")] = "frog"'
         in text
     )
     assert (
@@ -575,7 +576,7 @@ def test_op_query_arguments():
         in text
     )
     assert (
-        'favorite_day: Annotated[Optional[DayOfWeek], typer.Option(show_default=False, '
+        'favorite_day: Annotated[Optional[FavoriteDay], typer.Option(show_default=False, '
         'case_sensitive=True, help="")] = None'
         in text
     )
@@ -641,7 +642,6 @@ class Simple(str, Enum):  # noqa: F811
 
 """
 
-FOOBAR_ENUM = SIMPLE_ENUM.replace("Simple", "FooBar")
 NUMBER_ENUM = """\
 class SimpleNumber(int, Enum):  # noqa: F811
     VALUE_12 = 12
@@ -685,10 +685,9 @@ class Special(str, Enum):  # noqa: F811
 SIMPLE_PARAM = {
     TYPE: "string",
     ENUM: ["aOrB", "b_or_C", "-minus"], "$ref": "#/components/schemas/Simple",
-    "name": "fooBar",
+    "name": "simple",
 }
 
-FOOBAR_PARAM = {TYPE: "string", ENUM: ["aOrB", "b_or_C", "-minus"], "name": "fooBar"}
 NUMBER_PARAM = {TYPE: "integer", ENUM: [12, 37, 11], "name": "simple-number"}
 MIXED_PARAM = {TYPE: "string", ENUM: ["a", 1, True, "b"], "name": "mixed-values"}
 INT_STR_PARAM = {TYPE: "string", ENUM: ["10", "10.1"], "name": "int-strings"}
@@ -738,51 +737,16 @@ def test_enum_declaration(name, enum_type, values, expected):
         pytest.param(
             [],
             [],
-            {"fooBar": {TYPE: "string", ENUM: ["aOrB", "b_or_C", "-minus"], "x-reference": "Simple"}},
+            {"simple": {TYPE: "string", ENUM: ["aOrB", "b_or_C", "-minus"], "x-reference": "Simple"}},
             f"\n{SIMPLE_ENUM}",
             id="ref-body",
         ),
         pytest.param(
-            [FOOBAR_PARAM],
-            [],
-            {},
-            f"\n{FOOBAR_ENUM}",
-            id="unref-path",
-        ),
-        pytest.param(
-            [],
-            [FOOBAR_PARAM],
-            {},
-            f"\n{FOOBAR_ENUM}",
-            id="unref-query",
-        ),
-        pytest.param(
-            [],
-            [],
-            {"fooBar": {TYPE: "string", ENUM: ["aOrB", "b_or_C", "-minus"]}},
-            f"\n{FOOBAR_ENUM}",
-            id="unref-body",
-        ),
-        pytest.param(
-            [],
-            [],
-            {"foo.bar": {TYPE: "string", ENUM: ["aOrB", "b_or_C", "-minus"]}},
-            f"\n{FOOBAR_ENUM}",
-            id="subprop-body",
-        ),
-        pytest.param(
             [SIMPLE_PARAM],
             [SIMPLE_PARAM],
-            {"fooBar": {TYPE: "string", ENUM: ["aOrB", "b_or_C", "-minus"], "x-reference": "Simple"}},
+            {"simple": {TYPE: "string", ENUM: ["aOrB", "b_or_C", "-minus"], "x-reference": "Simple"}},
             f"\n{SIMPLE_ENUM}",
             id="de-dup",
-        ),
-        pytest.param(
-            [SIMPLE_PARAM],
-            [FOOBAR_PARAM],
-            {"fooBar": {TYPE: "string", ENUM: ["aOrB", "b_or_C", "-minus"]}},
-            f"\n{SIMPLE_ENUM}\n{FOOBAR_ENUM}",
-            id="multiple",
         ),
         pytest.param(
             [],
@@ -1210,7 +1174,7 @@ def test_op_body_arguments():
         in text
     )
     assert (
-        'flavor: Annotated[Optional[Species], '
+        'flavor: Annotated[Optional[Flavor], '
         'typer.Option(show_default=False, case_sensitive=False, help="Species type")] = None'
         in text
     )
@@ -1240,7 +1204,7 @@ def test_op_body_arguments():
         in text
     )
     assert (
-        'best_day: Annotated[Optional[DayOfWeek], typer.Option(show_default=False, '
+        'best_day: Annotated[Optional[BestDay], typer.Option(show_default=False, '
         'case_sensitive=True, help="enum buried in all-of")] = None'
         in text
     )


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Originally, tried to use the `$ref` value as the enum class name. This had problems when an object contained enum properties. The easiest and most reliable fix is to use the variable name as the enum class name.


## CHANGES
<!-- Please explain at a high-level the changes. -->

Updated the places where enum class name is pulled from the data, and several test cases.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->