### PR TITLE
Sort the sub-command imports

### DIFF
--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -114,10 +114,12 @@ from {self.package_name} import _tree as _t
 
     def subcommand_imports(self, subcommands: list[LayoutNode]) -> str:
         """Get the imports needed for the subcommands/children."""
-        return NL.join(
+        imports = [
             f"from {self.package_name}.{to_snake_case(n.identifier)} import app as {to_snake_case(n.identifier)}"
             for n in subcommands
-        )
+        ]
+        # NOTE: use sorted to avoid issue if user has used unsorted sub-commands
+        return NL.join(sorted(imports))
 
     def app_definition(self, node: LayoutNode) -> str:
         """Get the main typer application/start point, and "overhead" of dealing with children."""


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Imports should be sorted according to the import, and not rely on the sub-command order.

## CHANGES
<!-- Please explain at a high-level the changes. -->



<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->