### PR TITLE
Improve long help (doc-strings) for leading and trailing blank lines

### DIFF
--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -163,6 +163,15 @@ if __name__ == "__main__":
             return text
 
         lines = [_.rstrip() for _ in text.splitlines()]
+        # remove leading blank lines
+        while lines and not lines[0]:
+            lines.pop(0)
+        # remove trailing blank lines
+        while lines and not lines[-1]:
+            lines.pop()
+        if not lines:
+            return ""
+
         result = "'''"
         for line in lines:
             if not line:

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -93,6 +93,7 @@ def test_op_short_help(op, expected):
     ["op", "expected"],
     [
         pytest.param({}, "", id="empty"),
+        pytest.param({SUM: "  \n "}, "", id="whitespace"),
         pytest.param(
             {SUM: "Short summary"},
             "'''\n    Short summary\n    '''\n    ",
@@ -116,17 +117,17 @@ def test_op_short_help(op, expected):
         pytest.param(
             {DESC: 'Trailing whitespace  \t\nNext "line" with quotes'},
             """'''\n    Trailing whitespace\n    Next "line" with quotes\n    '''\n    """,
-            id='multi-line',
+            id='multi-line-quotes',
         ),
         pytest.param(
             {DESC: 'First\n  Leading whitespace'},
             """'''\n    First\n      Leading whitespace\n    '''\n    """,
-            id='multi-line',
+            id='multi-line-leading',
         ),
         pytest.param(
             {DESC: 'First\n\n  \n  After blanks'},
             """'''\n    First\n\n\n      After blanks\n    '''\n    """,
-            id='multi-line',
+            id='multi-line-trailing',
         ),
         pytest.param(
             {DESC: 'First\n  This is more than the alloted 30 characters so will be wrapped\nnext line'},
@@ -135,6 +136,16 @@ def test_op_short_help(op, expected):
                 "so will\n    be wrapped\n    next line\n    '''\n    "
             ),
             id='wrapped-line',
+        ),
+        pytest.param(
+            {DESC: 'Trailing blank lines  \t\n\t\n  \n '},
+            """'''\n    Trailing blank lines\n    '''\n    """,
+            id='blank-line-end',
+        ),
+        pytest.param(
+            {DESC: '\n\t  \nLeading blank lines'},
+            """'''\n    Leading blank lines\n    '''\n    """,
+            id='blank-line-start',
         ),
     ]
 )


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Improve the function doc-strings by removing leading/trailing blank lines. And, if there are not lines left, there's no doc-string.

## CHANGES
<!-- Please explain at a high-level the changes. -->

Updated the `Generator.op_long_help()` with the additional processing.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->