### PR TITLE
Fix typo in PageParams initialization with items property name

### DIFF
--- a/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/audit.py
+++ b/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/audit.py
@@ -81,7 +81,7 @@ def audit_list(
         page_size_value=page_size,
         page_start_name="page",
         page_start_value=page,
-        item_property_name="result",
+        items_property_name="result",
         next_property_name="next",
     )
     missing = []

--- a/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/environments.py
+++ b/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/environments.py
@@ -137,7 +137,7 @@ def environments_list(
         page_size_value=page_size,
         page_start_name="page",
         page_start_value=page,
-        item_property_name="result",
+        items_property_name="result",
         next_property_name="next",
     )
     missing = []
@@ -196,7 +196,7 @@ def environments_pushes_list(
         page_size_value=page_size,
         page_start_name="page",
         page_start_value=page,
-        item_property_name="result",
+        items_property_name="result",
         next_property_name="next",
     )
     missing = []

--- a/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/environments_tags.py
+++ b/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/environments_tags.py
@@ -163,7 +163,7 @@ def environments_tags_list(
         page_size_value=page_size,
         page_start_name="page",
         page_start_value=page,
-        item_property_name="result",
+        items_property_name="result",
         next_property_name="next",
     )
     missing = []

--- a/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/grants.py
+++ b/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/grants.py
@@ -209,7 +209,7 @@ def grants_list(
         page_size_value=page_size,
         page_start_name="page",
         page_start_value=page,
-        item_property_name="result",
+        items_property_name="result",
         next_property_name="next",
     )
     missing = []

--- a/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/memberships.py
+++ b/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/memberships.py
@@ -147,7 +147,7 @@ def memberships_list(
         page_size_value=page_size,
         page_start_name="page",
         page_start_value=page,
-        item_property_name="result",
+        items_property_name="result",
         next_property_name="next",
     )
     missing = []

--- a/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/users.py
+++ b/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/users.py
@@ -138,7 +138,7 @@ def users_list(
         page_size_value=page_size,
         page_start_name="page",
         page_start_value=page,
-        item_property_name="result",
+        items_property_name="result",
         next_property_name="next",
     )
     missing = []

--- a/openapi_spec_tools/cli_gen/generator.py
+++ b/openapi_spec_tools/cli_gen/generator.py
@@ -956,7 +956,7 @@ if __name__ == "__main__":
             args["item_start_name"] = quoted(names.item_start)
             args["item_start_value"] = self.variable_name(names.item_start)
         if names.items_property:
-            args["item_property_name"] = quoted(names.items_property)
+            args["items_property_name"] = quoted(names.items_property)
         if names.next_header:
             args["next_header_name"] = quoted(names.next_header)
         if names.next_property:

--- a/tests/cli_gen/test_generator.py
+++ b/tests/cli_gen/test_generator.py
@@ -1263,7 +1263,7 @@ def test_op_body_arguments():
         ),
         pytest.param(
             PaginationNames(items_property="northSouth"),
-            f'page_info = _r.PageParams({S2}max_count=_max_count,{S2}item_property_name="northSouth",{S1})',
+            f'page_info = _r.PageParams({S2}max_count=_max_count,{S2}items_property_name="northSouth",{S1})',
             id="items_property",
         ),
         pytest.param(


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Fix typo in `PageParams(items_property_name)`.

## CHANGES
<!-- Please explain at a high-level the changes. -->

Updated generator, tests, and regenerated code.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->