### PR TITLE
Fix paginated request issue

### DIFF
--- a/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/_requests.py
+++ b/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/_requests.py
@@ -229,8 +229,11 @@ def depaginate(
     _params = deepcopy(params or {})
     _headers = deepcopy(headers or {})
     pretty_url = None
+    next_url = None
 
+    page_start = page_params.page_start_value or 0
     page_count = 0
+    item_start = page_params.item_start_value or 0
     item_count = 0
     page_size = page_params.page_size_value or 0
     max_count = page_params.max_count
@@ -240,17 +243,15 @@ def depaginate(
     if page_params.page_size_name and page_params.page_size_value is not None:
         _params[page_params.page_size_name] = page_size
 
-    if page_params.item_start_name and page_params.item_start_value is not None:
-        offset = page_params.item_start_value
-        _params[page_params.item_start_name] = page_params.item_start_value
-
     while _url:
-        if page_params.page_start_name:
-            _params[page_params.page_start_name] = page_count
-        if page_params.item_start_name:
-            _params[page_params.item_start_name] = offset
-
-        if pretty_url != _url:
+        if next_url:
+            pretty_url = next_url
+            _params = {}
+        else:
+            if page_params.page_start_name:
+                _params[page_params.page_start_name] = page_start + page_count
+            if page_params.item_start_name:
+                _params[page_params.item_start_name] = item_start + item_count
             pretty_url = _url + _pretty_params(_params)
 
         logger.debug(f"Requesting {GET} {pretty_url} count={page_count + 1}")
@@ -269,12 +270,10 @@ def depaginate(
         # update the URL from the provided info
         if page_params.next_header_name:
             _url = response.headers.get(page_params.next_header_name)
-            pretty_url = _url
+            next_url = _url
         elif page_params.next_property_name:
             _url = response.json().get(page_params.next_property_name)
-            pretty_url = _url
-        else:
-            pretty_url = None
+            next_url = _url
 
         # some book-keeping
         curr_len = len(current)

--- a/examples/github/github_gen_cli/_requests.py
+++ b/examples/github/github_gen_cli/_requests.py
@@ -229,8 +229,11 @@ def depaginate(
     _params = deepcopy(params or {})
     _headers = deepcopy(headers or {})
     pretty_url = None
+    next_url = None
 
+    page_start = page_params.page_start_value or 0
     page_count = 0
+    item_start = page_params.item_start_value or 0
     item_count = 0
     page_size = page_params.page_size_value or 0
     max_count = page_params.max_count
@@ -240,17 +243,15 @@ def depaginate(
     if page_params.page_size_name and page_params.page_size_value is not None:
         _params[page_params.page_size_name] = page_size
 
-    if page_params.item_start_name and page_params.item_start_value is not None:
-        offset = page_params.item_start_value
-        _params[page_params.item_start_name] = page_params.item_start_value
-
     while _url:
-        if page_params.page_start_name:
-            _params[page_params.page_start_name] = page_count
-        if page_params.item_start_name:
-            _params[page_params.item_start_name] = offset
-
-        if pretty_url != _url:
+        if next_url:
+            pretty_url = next_url
+            _params = {}
+        else:
+            if page_params.page_start_name:
+                _params[page_params.page_start_name] = page_start + page_count
+            if page_params.item_start_name:
+                _params[page_params.item_start_name] = item_start + item_count
             pretty_url = _url + _pretty_params(_params)
 
         logger.debug(f"Requesting {GET} {pretty_url} count={page_count + 1}")
@@ -269,12 +270,10 @@ def depaginate(
         # update the URL from the provided info
         if page_params.next_header_name:
             _url = response.headers.get(page_params.next_header_name)
-            pretty_url = _url
+            next_url = _url
         elif page_params.next_property_name:
             _url = response.json().get(page_params.next_property_name)
-            pretty_url = _url
-        else:
-            pretty_url = None
+            next_url = _url
 
         # some book-keeping
         curr_len = len(current)

--- a/examples/pets-cli/pets_cli/_requests.py
+++ b/examples/pets-cli/pets_cli/_requests.py
@@ -229,8 +229,11 @@ def depaginate(
     _params = deepcopy(params or {})
     _headers = deepcopy(headers or {})
     pretty_url = None
+    next_url = None
 
+    page_start = page_params.page_start_value or 0
     page_count = 0
+    item_start = page_params.item_start_value or 0
     item_count = 0
     page_size = page_params.page_size_value or 0
     max_count = page_params.max_count
@@ -240,17 +243,15 @@ def depaginate(
     if page_params.page_size_name and page_params.page_size_value is not None:
         _params[page_params.page_size_name] = page_size
 
-    if page_params.item_start_name and page_params.item_start_value is not None:
-        offset = page_params.item_start_value
-        _params[page_params.item_start_name] = page_params.item_start_value
-
     while _url:
-        if page_params.page_start_name:
-            _params[page_params.page_start_name] = page_count
-        if page_params.item_start_name:
-            _params[page_params.item_start_name] = offset
-
-        if pretty_url != _url:
+        if next_url:
+            pretty_url = next_url
+            _params = {}
+        else:
+            if page_params.page_start_name:
+                _params[page_params.page_start_name] = page_start + page_count
+            if page_params.item_start_name:
+                _params[page_params.item_start_name] = item_start + item_count
             pretty_url = _url + _pretty_params(_params)
 
         logger.debug(f"Requesting {GET} {pretty_url} count={page_count + 1}")
@@ -269,12 +270,10 @@ def depaginate(
         # update the URL from the provided info
         if page_params.next_header_name:
             _url = response.headers.get(page_params.next_header_name)
-            pretty_url = _url
+            next_url = _url
         elif page_params.next_property_name:
             _url = response.json().get(page_params.next_property_name)
-            pretty_url = _url
-        else:
-            pretty_url = None
+            next_url = _url
 
         # some book-keeping
         curr_len = len(current)

--- a/openapi_spec_tools/cli_gen/_requests.py
+++ b/openapi_spec_tools/cli_gen/_requests.py
@@ -225,8 +225,11 @@ def depaginate(
     _params = deepcopy(params or {})
     _headers = deepcopy(headers or {})
     pretty_url = None
+    next_url = None
 
+    page_start = page_params.page_start_value or 0
     page_count = 0
+    item_start = page_params.item_start_value or 0
     item_count = 0
     page_size = page_params.page_size_value or 0
     max_count = page_params.max_count
@@ -236,17 +239,15 @@ def depaginate(
     if page_params.page_size_name and page_params.page_size_value is not None:
         _params[page_params.page_size_name] = page_size
 
-    if page_params.item_start_name and page_params.item_start_value is not None:
-        offset = page_params.item_start_value
-        _params[page_params.item_start_name] = page_params.item_start_value
-
     while _url:
-        if page_params.page_start_name:
-            _params[page_params.page_start_name] = page_count
-        if page_params.item_start_name:
-            _params[page_params.item_start_name] = offset
-
-        if pretty_url != _url:
+        if next_url:
+            pretty_url = next_url
+            _params = {}
+        else:
+            if page_params.page_start_name:
+                _params[page_params.page_start_name] = page_start + page_count
+            if page_params.item_start_name:
+                _params[page_params.item_start_name] = item_start + item_count
             pretty_url = _url + _pretty_params(_params)
 
         logger.debug(f"Requesting {GET} {pretty_url} count={page_count + 1}")
@@ -265,12 +266,10 @@ def depaginate(
         # update the URL from the provided info
         if page_params.next_header_name:
             _url = response.headers.get(page_params.next_header_name)
-            pretty_url = _url
+            next_url = _url
         elif page_params.next_property_name:
             _url = response.json().get(page_params.next_property_name)
-            pretty_url = _url
-        else:
-            pretty_url = None
+            next_url = _url
 
         # some book-keeping
         curr_len = len(current)


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

The `_requests.depaginate()` was failing to return when there was more than one page.

## CHANGES
<!-- Please explain at a high-level the changes. -->

Updated `_requests.depaginate()`:
1. Introduce a `next_url` parameter to track when using a next URL (either header or body)
    * When the `next_url` is used, do NOT provide parameters in the request (they're assumed to be in the URL)
2. Introduce a `item_start` and `page_start` to track the user start points
   * Use these plus the corresponding `_count` items to update the parameters

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->