### PR TITLE
Improve table creation for a list

### DIFF
--- a/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/_display.py
+++ b/examples/cloudtruth-gen-cli/cloudtruth_gen_cli/_display.py
@@ -129,6 +129,16 @@ def _get_name_key(item: dict[Any, Any], key_fields: list[str]) -> Optional[str]:
     return None
 
 
+def _get_other_key(item: dict[Any, Any], name_key: str) -> Optional[str]:
+    """Find the "other" key (if there's just one value)."""
+    keys = set(item.keys())
+    keys.remove(name_key)
+    if len(keys) != 1:
+        return None
+
+    return keys.pop()
+
+
 def _is_url(s: str, url_prefixes: list[str]) -> bool:
     """Rudimentary check for somethingt starting with URL prefix."""
     return any(s.startswith(p) for p in url_prefixes)
@@ -164,8 +174,27 @@ def _create_list_table(
             table.add_row(_table_cell_value(item, config))
         return table
 
-    # create a table with identifier in left column, and rest of data in right column
+    # if there's just one property besides the key, use that as the label
     name_label = name_key[0].upper() + name_key[1:]
+    other_key = _get_other_key(items[0], name_key)
+    if other_key:
+        other_name = other_key[0].upper() + other_key[1:]
+        fields = [name_label, other_name]
+        table = RichTable(
+            *fields,
+            outer=outer,
+            show_lines=True,
+            caption=caption,
+            row_props=config.row_properties,
+        )
+        for item in items:
+            # id may be an int, so convert to string before truncating
+            name = _safe(item.pop(name_key, config.unknown_label))
+            body = _table_cell_value(item.get(other_key), config)
+            table.add_row(_truncate(name, config.key_max_len), body)
+        return table
+
+    # create a table with identifier in left column, and rest of data in right column
     fields = [name_label, config.properties_label]
     table = RichTable(
         *fields,

--- a/examples/github/github_gen_cli/_display.py
+++ b/examples/github/github_gen_cli/_display.py
@@ -129,6 +129,16 @@ def _get_name_key(item: dict[Any, Any], key_fields: list[str]) -> Optional[str]:
     return None
 
 
+def _get_other_key(item: dict[Any, Any], name_key: str) -> Optional[str]:
+    """Find the "other" key (if there's just one value)."""
+    keys = set(item.keys())
+    keys.remove(name_key)
+    if len(keys) != 1:
+        return None
+
+    return keys.pop()
+
+
 def _is_url(s: str, url_prefixes: list[str]) -> bool:
     """Rudimentary check for somethingt starting with URL prefix."""
     return any(s.startswith(p) for p in url_prefixes)
@@ -164,8 +174,27 @@ def _create_list_table(
             table.add_row(_table_cell_value(item, config))
         return table
 
-    # create a table with identifier in left column, and rest of data in right column
+    # if there's just one property besides the key, use that as the label
     name_label = name_key[0].upper() + name_key[1:]
+    other_key = _get_other_key(items[0], name_key)
+    if other_key:
+        other_name = other_key[0].upper() + other_key[1:]
+        fields = [name_label, other_name]
+        table = RichTable(
+            *fields,
+            outer=outer,
+            show_lines=True,
+            caption=caption,
+            row_props=config.row_properties,
+        )
+        for item in items:
+            # id may be an int, so convert to string before truncating
+            name = _safe(item.pop(name_key, config.unknown_label))
+            body = _table_cell_value(item.get(other_key), config)
+            table.add_row(_truncate(name, config.key_max_len), body)
+        return table
+
+    # create a table with identifier in left column, and rest of data in right column
     fields = [name_label, config.properties_label]
     table = RichTable(
         *fields,

--- a/examples/pets-cli/pets_cli/_display.py
+++ b/examples/pets-cli/pets_cli/_display.py
@@ -129,6 +129,16 @@ def _get_name_key(item: dict[Any, Any], key_fields: list[str]) -> Optional[str]:
     return None
 
 
+def _get_other_key(item: dict[Any, Any], name_key: str) -> Optional[str]:
+    """Find the "other" key (if there's just one value)."""
+    keys = set(item.keys())
+    keys.remove(name_key)
+    if len(keys) != 1:
+        return None
+
+    return keys.pop()
+
+
 def _is_url(s: str, url_prefixes: list[str]) -> bool:
     """Rudimentary check for somethingt starting with URL prefix."""
     return any(s.startswith(p) for p in url_prefixes)
@@ -164,8 +174,27 @@ def _create_list_table(
             table.add_row(_table_cell_value(item, config))
         return table
 
-    # create a table with identifier in left column, and rest of data in right column
+    # if there's just one property besides the key, use that as the label
     name_label = name_key[0].upper() + name_key[1:]
+    other_key = _get_other_key(items[0], name_key)
+    if other_key:
+        other_name = other_key[0].upper() + other_key[1:]
+        fields = [name_label, other_name]
+        table = RichTable(
+            *fields,
+            outer=outer,
+            show_lines=True,
+            caption=caption,
+            row_props=config.row_properties,
+        )
+        for item in items:
+            # id may be an int, so convert to string before truncating
+            name = _safe(item.pop(name_key, config.unknown_label))
+            body = _table_cell_value(item.get(other_key), config)
+            table.add_row(_truncate(name, config.key_max_len), body)
+        return table
+
+    # create a table with identifier in left column, and rest of data in right column
     fields = [name_label, config.properties_label]
     table = RichTable(
         *fields,

--- a/examples/pets-cli/tests/test_display.py
+++ b/examples/pets-cli/tests/test_display.py
@@ -69,6 +69,12 @@ UNSAFE_DICT = {
     ],
 }
 
+SUMMARY_LIST = [
+    {"name": "sna", "data": 1},
+    {"name": "foo", "data": {"a": 1, "b": 2}},
+    {"name": "bar", "data": None},
+]
+
 
 def test_rich_table_defaults_outer():
     columns = ["col 1", "Column B", "III"]
@@ -432,14 +438,7 @@ def test_unsafe_table():
     ic1 = inner.columns[1]
 
     assert ic0._cells[0] == "foo"
-    deeper = ic1._cells[0]
-    assert deeper.row_count == 1
-    assert len(deeper.columns) == 2
-
-    dc0 = deeper.columns[0]
-    dc1 = deeper.columns[1]
-    assert dc0._cells[0] == "body"
-    assert dc1._cells[0] == "\\[//]contains escape"
+    assert ic1._cells[0] == "\\[//]contains escape"
 
 
 SIMPLE_TABLE = """\
@@ -478,6 +477,27 @@ def test_display(data, fmt, expected):
         display(data, fmt, OutputStyle.NONE)
         output = mock_stdout.getvalue()
         assert to_ascii(expected) == to_ascii(output)
+
+
+SUMMARY_TABLE = """\
+┏━━━━━━┳━━━━━━━━┓
+┃ Name ┃ Data   ┃
+┡━━━━━━╇━━━━━━━━┩
+│ sna  │ 1      │
+├──────┼────────┤
+│ foo  │  a  1  │
+│      │  b  2  │
+├──────┼────────┤
+│ bar  │ None   │
+└──────┴────────┘
+Found 3 items
+"""
+
+def test_summary_list():
+    with mock.patch('sys.stdout', new_callable=StringIO) as mock_stdout:
+        display(SUMMARY_LIST, OutputFormat.TABLE, OutputStyle.NONE)
+        output = mock_stdout.getvalue()
+        assert to_ascii(SUMMARY_TABLE) == to_ascii(output)
 
 
 @pytest.mark.parametrize(

--- a/openapi_spec_tools/cli_gen/_display.py
+++ b/openapi_spec_tools/cli_gen/_display.py
@@ -125,6 +125,16 @@ def _get_name_key(item: dict[Any, Any], key_fields: list[str]) -> Optional[str]:
     return None
 
 
+def _get_other_key(item: dict[Any, Any], name_key: str) -> Optional[str]:
+    """Find the "other" key (if there's just one value)."""
+    keys = set(item.keys())
+    keys.remove(name_key)
+    if len(keys) != 1:
+        return None
+
+    return keys.pop()
+
+
 def _is_url(s: str, url_prefixes: list[str]) -> bool:
     """Rudimentary check for somethingt starting with URL prefix."""
     return any(s.startswith(p) for p in url_prefixes)
@@ -160,8 +170,27 @@ def _create_list_table(
             table.add_row(_table_cell_value(item, config))
         return table
 
-    # create a table with identifier in left column, and rest of data in right column
+    # if there's just one property besides the key, use that as the label
     name_label = name_key[0].upper() + name_key[1:]
+    other_key = _get_other_key(items[0], name_key)
+    if other_key:
+        other_name = other_key[0].upper() + other_key[1:]
+        fields = [name_label, other_name]
+        table = RichTable(
+            *fields,
+            outer=outer,
+            show_lines=True,
+            caption=caption,
+            row_props=config.row_properties,
+        )
+        for item in items:
+            # id may be an int, so convert to string before truncating
+            name = _safe(item.pop(name_key, config.unknown_label))
+            body = _table_cell_value(item.get(other_key), config)
+            table.add_row(_truncate(name, config.key_max_len), body)
+        return table
+
+    # create a table with identifier in left column, and rest of data in right column
     fields = [name_label, config.properties_label]
     table = RichTable(
         *fields,

--- a/tests/cli_gen/test_display.py
+++ b/tests/cli_gen/test_display.py
@@ -65,6 +65,12 @@ UNSAFE_DICT = {
     ],
 }
 
+SUMMARY_LIST = [
+    {"name": "sna", "data": 1},
+    {"name": "foo", "data": {"a": 1, "b": 2}},
+    {"name": "bar", "data": None},
+]
+
 
 def test_rich_table_defaults_outer():
     columns = ["col 1", "Column B", "III"]
@@ -428,14 +434,7 @@ def test_unsafe_table():
     ic1 = inner.columns[1]
 
     assert ic0._cells[0] == "foo"
-    deeper = ic1._cells[0]
-    assert deeper.row_count == 1
-    assert len(deeper.columns) == 2
-
-    dc0 = deeper.columns[0]
-    dc1 = deeper.columns[1]
-    assert dc0._cells[0] == "body"
-    assert dc1._cells[0] == "\\[//]contains escape"
+    assert ic1._cells[0] == "\\[//]contains escape"
 
 
 SIMPLE_TABLE = """\
@@ -474,6 +473,27 @@ def test_display(data, fmt, expected):
         display(data, fmt, OutputStyle.NONE)
         output = mock_stdout.getvalue()
         assert to_ascii(expected) == to_ascii(output)
+
+
+SUMMARY_TABLE = """\
+┏━━━━━━┳━━━━━━━━┓
+┃ Name ┃ Data   ┃
+┡━━━━━━╇━━━━━━━━┩
+│ sna  │ 1      │
+├──────┼────────┤
+│ foo  │  a  1  │
+│      │  b  2  │
+├──────┼────────┤
+│ bar  │ None   │
+└──────┴────────┘
+Found 3 items
+"""
+
+def test_summary_list():
+    with mock.patch('sys.stdout', new_callable=StringIO) as mock_stdout:
+        display(SUMMARY_LIST, OutputFormat.TABLE, OutputStyle.NONE)
+        output = mock_stdout.getvalue()
+        assert to_ascii(SUMMARY_TABLE) == to_ascii(output)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Improve the table creation for a list of item where there's only one property. This would be common when using `summaryFields` properties. 


## CHANGES
<!-- Please explain at a high-level the changes. -->

When only one "main" property, use the property name as the column heading and display just the value in the column.

## EXAMPLE

For a list that looks like:
```json
[
    {"name": "sna", "data": 1},
    {"name": "foo", "data": {"a": 1, "b": 2}},
    {"name": "bar", "data": None},
]
```

This is what the new display looks like:
```terminal
┏━━━━━━┳━━━━━━━━┓
┃ Name ┃ Data   ┃
┡━━━━━━╇━━━━━━━━┩
│ sna  │ 1      │
├──────┼────────┤
│ foo  │  a  1  │
│      │  b  2  │
├──────┼────────┤
│ bar  │ None   │
└──────┴────────┘
Found 3 items
```

This is what the old display would look like:
```terminal
┏━━━━━━┳━━━━━━━━━━━━━━━━┓
┃ Name ┃ Properties     ┃
┡━━━━━━╇━━━━━━━━━━━━━━━━┩
│ sna  │  data  1       │
├──────┼────────────────┤
│ foo  │  data   a  1   │
│      │         b  2   │
├──────┼────────────────┤
│ bar  │  data  None    │
└──────┴────────────────┘
Found 3 items            

```

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->