### PR TITLE
Add tool to generate a layout file from the OpenAPI spec

### DIFF
--- a/openapi_spec_tools/cli_gen/cli.py
+++ b/openapi_spec_tools/cli_gen/cli.py
@@ -39,6 +39,8 @@ from openapi_spec_tools.cli_gen.layout import operation_order
 from openapi_spec_tools.cli_gen.layout import subcommand_missing_properties
 from openapi_spec_tools.cli_gen.layout import subcommand_order
 from openapi_spec_tools.cli_gen.layout import subcommand_references
+from openapi_spec_tools.cli_gen.layout_generator import LayoutGenerator
+from openapi_spec_tools.cli_gen.layout_generator import write_layout
 from openapi_spec_tools.cli_gen.layout_types import LayoutNode
 from openapi_spec_tools.types import OasField
 from openapi_spec_tools.utils import open_oas
@@ -270,6 +272,29 @@ def layout_operations(
     tree = layout_tree_with_error_handling(filename, start=start)
     operations = _operations(tree)
     print('\n'.join(sorted(operations)))
+    return
+
+
+@layout.command(
+    "suggest",
+    short_help="Suggest layout based on OpenAPI spec"
+)
+def layout_suggest(
+    openapi_file: OpenApiFilenameArgument,
+    output_file: Annotated[str, typer.Argument(show_default=False, help="File name for output")],
+    prefix: Annotated[str, typer.Option(show_default=False, help="Prefix common to all paths")] = "",
+    log_level: LogLevelOption = "info",
+) -> None:
+    init_logging(log_level, GENERATOR_LOG_CLASS)
+    oas = open_oas_with_error_handling(openapi_file)
+    generator = LayoutGenerator()
+    node = generator.generate(oas, prefix)
+
+    start = datetime.now()
+    write_layout(output_file, node)
+    delta = datetime.now() - start
+    get_logger(GENERATOR_LOG_CLASS).info(f"Writing {output_file} took {delta.total_seconds()} seconds")
+    print(f"Wrote {output_file}")
     return
 
 

--- a/openapi_spec_tools/cli_gen/layout_generator.py
+++ b/openapi_spec_tools/cli_gen/layout_generator.py
@@ -1,0 +1,153 @@
+"""Declares the LayoutGenerator for inferring a layout from an OpenAPI specification."""
+from typing import Any
+
+from openapi_spec_tools.cli_gen.layout import DEFAULT_START
+from openapi_spec_tools.cli_gen.layout_types import LayoutField
+from openapi_spec_tools.cli_gen.layout_types import LayoutNode
+from openapi_spec_tools.cli_gen.utils import to_snake_case
+from openapi_spec_tools.types import OasField
+
+CREATE = "create"
+DELETE = "delete"
+LIST = "list"
+SET = "set"
+SHOW = "show"
+UPDATE = "update"
+
+
+class LayoutGenerator:
+    """Generates a layout from the OpenAPI spec."""
+
+    def __init__(self):
+        """Initialize the generator with internal values."""
+        self.common_ops = {
+            "add": CREATE,
+            "create": CREATE,
+            "post": CREATE,
+            "delete": DELETE,
+            "remove": DELETE,
+            "list": LIST,
+            "retrieve": SHOW,
+            "get": SHOW,
+            "update": UPDATE,
+            "patch": UPDATE,
+            "put": SET,
+        }
+
+    @staticmethod
+    def path_to_parts(path_name: str, prefix: str) -> list[str]:
+        """Break the path string into parts, and removes the parameterized values."""
+        shortened = path_name if not path_name.startswith(prefix) else path_name.replace(prefix, "", 1)
+        parts = [
+            item.strip()
+            for item in shortened.split('/')
+            if item.strip() and '{' not in item  # ignore parameters
+        ]
+        return parts
+
+    @staticmethod
+    def parts_to_commands(path_parts: list[str]) -> list[str]:
+        """Convert list of path parts to list of commands."""
+        return [to_snake_case(part).replace("_", "-") for part in path_parts]
+
+    @staticmethod
+    def commands_to_identifier(commands: list[str]) -> str:
+        """Convert the list of commands into an identifier."""
+        return "_".join([to_snake_case(x).replace("-", "_") for x in commands])
+
+    def suggest_command(self, method: str, op_id: str) -> str:
+        """Suggest a command based on the method and operationId."""
+        # the patch/put methods often have similar operationId's so handle those first
+        _method = method.lower()
+        if _method == "put":
+            return SET
+        if _method == "patch":
+            return UPDATE
+
+        operation = to_snake_case(op_id).split('_')
+        begin = operation[0]
+        if begin in self.common_ops:
+            return self.common_ops.get(begin)
+        end = operation[-1]
+        if end in self.common_ops:
+            return self.common_ops.get(end)
+
+        # default to using the method... last resort because get single-item and list use same
+        return self.common_ops.get(_method, _method)
+
+    def get_or_create_node_with_parents(self, node: LayoutNode, commands: list[str]) -> LayoutNode:
+        """Create the node for the current commands and any required parents."""
+        if not commands:
+            return node
+
+        existing = node.find(*commands)
+        if existing:
+            return existing
+
+        current = node
+        for cmd_len in range(1, len(commands)):
+            parent_cmds = commands[:cmd_len]
+            command = parent_cmds[cmd_len - 1]
+            child = current.find(command)
+            if not child:
+                description = "Manage " + " ".join(parent_cmds)
+                child = LayoutNode(command, self.commands_to_identifier(parent_cmds), description=description)
+                current.children.append(child)
+            current = child
+
+        identifier = self.commands_to_identifier(commands)
+        description = "Manage " + " ".join(commands)
+        path_node = LayoutNode(command=commands[-1], identifier=identifier, description=description)
+        current.children.append(path_node)
+        return path_node
+
+    def generate(self, oas: dict[str, Any], prefix: str) -> LayoutNode:
+        """Create a suggested layout for the provided OpenAPI spec."""
+        main = LayoutNode(DEFAULT_START, DEFAULT_START, description="CLI to manage your application")
+
+        paths = oas.get(OasField.PATHS, {})
+        for path_name, path_data in paths.items():
+            path_parts = self.path_to_parts(path_name, prefix)
+            commands = self.parts_to_commands(path_parts)
+
+            for method, op_data in path_data.items():
+                if method == OasField.PARAMS:
+                    continue
+
+                path_node = self.get_or_create_node_with_parents(main, commands)
+                op_id = op_data.get(OasField.OP_ID)
+                command = self.suggest_command(method, op_id)
+                path_node.children.append(
+                    LayoutNode(command=command, identifier=op_id)
+                )
+
+        return main
+
+
+def layout_node_text(node: LayoutNode) -> str:
+    """Create text for node, and all children."""
+    indent = "    "
+    text = f"{node.identifier}:\n"
+    text += f"{indent}{LayoutField.DESCRIPTION}: {node.description}\n"
+    text += f"{indent}{LayoutField.OPERATIONS}:\n"
+
+    sorted_children = sorted(node.children, key=lambda x: x.command)
+    for child in sorted_children:
+        text += f"{indent}- {LayoutField.NAME}: {child.command}\n"
+        flavor = LayoutField.OP_ID if not child.children else LayoutField.SUB_ID
+        text += f"{indent}  {flavor}: {child.identifier}\n"
+    text += "\n"
+
+    # recursively generate sections for sub-commands
+    sorted_subcommands = sorted(node.subcommands(), key=lambda x: x.identifier)
+    for child in sorted_subcommands:
+        text += layout_node_text(child)
+
+    return text
+
+
+def write_layout(filename: str, node: LayoutNode):
+    """Write the text from the node to the specified file."""
+    with open(filename, "w", encoding="utf-8", newline="\n") as fp:
+        fp.write(layout_node_text(node))
+

--- a/openapi_spec_tools/cli_gen/layout_types.py
+++ b/openapi_spec_tools/cli_gen/layout_types.py
@@ -93,6 +93,9 @@ class LayoutNode:
 
     def find(self, *args) -> Optional["LayoutNode"]:
         """Search for the provided commands."""
+        if not args:
+            return None
+
         for child in self.children:
             if child.command == args[0]:
                 if len(args) == 1:

--- a/tests/cli_gen/test_cli.py
+++ b/tests/cli_gen/test_cli.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 from tempfile import TemporaryDirectory
 from typing import Any
 from typing import Optional
@@ -15,6 +16,7 @@ from openapi_spec_tools.cli_gen.cli import generate_cli
 from openapi_spec_tools.cli_gen.cli import generate_unreferenced
 from openapi_spec_tools.cli_gen.cli import layout_check_format
 from openapi_spec_tools.cli_gen.cli import layout_operations
+from openapi_spec_tools.cli_gen.cli import layout_suggest
 from openapi_spec_tools.cli_gen.cli import layout_tree
 from openapi_spec_tools.cli_gen.cli import layout_tree_with_error_handling
 from openapi_spec_tools.cli_gen.cli import open_layout_with_error_handling
@@ -382,6 +384,27 @@ def test_layout_operations(filename, start, expected) -> None:
 
         output = mock_stdout.getvalue()
         assert to_ascii(output) == to_ascii(expected)
+
+
+def test_layout_suggest():
+    layout_file = NamedTemporaryFile()
+    layout_suggest(asset_filename("pet.yaml"), layout_file.name, prefix="/pets")
+
+    dest_file = Path(layout_file.name)
+    text = dest_file.read_text(encoding="utf-8", errors="ignore")
+    expected = """\
+main:
+    description: CLI to manage your application
+    operations:
+    - name: create
+      operationId: createPets
+    - name: list
+      operationId: listPets
+    - name: show
+      operationId: showPetById
+
+"""
+    assert expected == text
 
 
 @pytest.mark.parametrize(

--- a/tests/cli_gen/test_layout_generator.py
+++ b/tests/cli_gen/test_layout_generator.py
@@ -1,0 +1,155 @@
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+import pytest
+
+from openapi_spec_tools.cli_gen.layout_generator import LayoutGenerator
+from openapi_spec_tools.cli_gen.layout_generator import write_layout
+from openapi_spec_tools.utils import open_oas
+from tests.helpers import asset_filename
+
+
+@pytest.mark.parametrize(
+    ["path", "prefix", "expected"],
+    [
+        pytest.param("", "", [], id="empty"),
+        pytest.param("/foo", "/foo", [], id="only-prefix"),
+        pytest.param("/foo", "/foo/foo", ["foo"], id="single-prefix"),
+        pytest.param("/foo/{bar}", "/foo", [], id="prefix-id"),
+        pytest.param("/sna/foo/{bar}", "/foo", ["sna", "foo"], id="late-prefix"),
+        pytest.param("/sna/foo/{bar}/all", "/sna", ["foo", "all"], id="all"),
+    ],
+)
+def test_path_to_parts(path, prefix, expected):
+    uut = LayoutGenerator()
+    assert expected == uut.path_to_parts(path, prefix)
+
+
+@pytest.mark.parametrize(
+    ["parts", "expected"],
+    [
+        pytest.param([], [], id="empty"),
+        pytest.param(["foo"], ["foo"], id="simple"),
+        pytest.param(["Foo"], ["foo"], id="title"),
+        pytest.param(["FooBar"], ["foo-bar"], id="camel"),
+        pytest.param(["foo_bar"], ["foo-bar"], id="snake"),
+    ]
+)
+def test_parts_to_commands(parts, expected):
+    uut = LayoutGenerator()
+    assert expected == uut.parts_to_commands(parts)
+
+
+@pytest.mark.parametrize(
+    ["commands", "expected"],
+    [
+        pytest.param([], "", id="empty"),
+        pytest.param(["foo"], "foo", id="simple"),
+        pytest.param(["sna", "foo"], "sna_foo", id="multiple"),
+        pytest.param(["sna", "fooBar"], "sna_foo_bar", id="camel"),
+        pytest.param(["sna_foo", "bar"], "sna_foo_bar", id="snake"),
+    ]
+)
+def test_commands_to_identifier(commands, expected):
+    uut = LayoutGenerator()
+    assert expected == uut.commands_to_identifier(commands)
+
+
+@pytest.mark.parametrize(
+    ["method", "op_id", "expected"],
+    [
+        pytest.param("PUT", "foo_list", "set", id="put"),
+        pytest.param("PaTCh", "foo_list", "update", id="update"),
+        pytest.param("delete", "add_item", "create", id="begin"),
+        pytest.param("delete", "itemRetrieve", "show", id="end"),
+        pytest.param("delete", "item", "delete", id="method"),
+    ]
+)
+def test_suggest_command(method, op_id, expected):
+    uut = LayoutGenerator()
+    assert expected == uut.suggest_command(method, op_id)
+
+
+def test_generate_pets():
+    oas = open_oas(asset_filename("pet.yaml"))
+
+    uut = LayoutGenerator()
+    node = uut.generate(oas, "/pets")
+    assert [] == node.subcommands()
+    ops = node.operations()
+    assert 3 == len(ops)
+    assert {"list", "create", "show"} == {o.command for o in ops}
+    assert {"listPets", "createPets", "showPetById"} == {o.identifier for o in ops}
+
+
+def test_generate_cloudtruth():
+    oas = open_oas(asset_filename("ct.yaml"))
+
+    uut = LayoutGenerator()
+    node = uut.generate(oas, "/api/v1")
+
+    # no direct operations -- all in sub-commands
+    assert [] == node.operations()
+
+    subcmds = node.subcommands()
+    assert 17 == len(subcmds)
+
+    # a couple spot checks
+    current_user = node.find("users", "current")
+    assert [] == current_user.subcommands()
+    sub_ops = current_user.operations()
+    assert 1 == len(sub_ops)
+    item = sub_ops[0]
+    assert "show" == item.command
+    assert "users_current_retrieve" == item.identifier
+
+    key_list = node.find("integrations", "azure", "key-vault", "list")
+    assert "list" == key_list.command
+    assert "integrations_azure_key_vault_list" == key_list.identifier
+
+
+def test_generate_misc():
+    oas = open_oas(asset_filename("misc.yaml"))
+
+    uut = LayoutGenerator()
+    node = uut.generate(oas, "")
+    assert [] == node.operations()
+
+    sub_cmds = node.subcommands()
+    assert 2 == len(sub_cmds)
+
+    pets = node.find("pets")
+    pet_cmds = pets.operations()
+    assert 2 == len(pet_cmds)
+    assert {"show", "delete"} == {cmd.command for cmd in pet_cmds}
+
+
+def test_generate_node_file():
+    oas = open_oas(asset_filename("pet.yaml"))
+    file = NamedTemporaryFile()
+    generator = LayoutGenerator()
+    node = generator.generate(oas, "")
+
+    write_layout(file.name, node)
+
+    dst_file = Path(file.name)
+    text = dst_file.read_text(encoding="utf-8", errors="ignore")
+    expected = '''\
+main:
+    description: CLI to manage your application
+    operations:
+    - name: pets
+      subcommandId: pets
+
+pets:
+    description: Manage pets
+    operations:
+    - name: create
+      operationId: createPets
+    - name: list
+      operationId: listPets
+    - name: show
+      operationId: showPetById
+'''
+    assert expected in text
+

--- a/tests/cli_gen/test_layout_utils.py
+++ b/tests/cli_gen/test_layout_utils.py
@@ -525,6 +525,7 @@ def test_file_to_tree() -> None:
 @pytest.mark.parametrize(
     ["search_args", "expected"],
     [
+        pytest.param((), None, id="no-args"),
         pytest.param(("foo"), None, id="not-found"),
         pytest.param(("pet", "feed"), None, id="child-not-found"),
         pytest.param(


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Make it easier to get going with a complete CLI for your OpenAPI specification. 


## CHANGES
<!-- Please explain at a high-level the changes. -->

Add layout generation tools. The path is used to determine the hierarchy of the commands.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->