### PR TITLE
Fix API imports for copied files

### DIFF
--- a/openapi_spec_tools/api_gen/files.py
+++ b/openapi_spec_tools/api_gen/files.py
@@ -46,6 +46,8 @@ def copy_api_infrastructure(dst_dir: str, package_name: str):
     dpath = Path(dst_dir)
     replacements = {
         __package__: package_name,
+        "openapi_spec_tools.api_gen": package_name,
+        "openapi_spec_tools.base_gen": package_name,
     }
     for src, dst in INFRASTRUCTURE_FILES.items():
         dfile = dpath / dst

--- a/tests/api_gen/test_files.py
+++ b/tests/api_gen/test_files.py
@@ -96,3 +96,8 @@ def test_copy_api_infrastructure():
     }
     assert filenames == expected
 
+    # make sure all the imports have been updated
+    for fname in filenames:
+        file = dst_path / fname
+        text = file.read_text()
+        assert "from openapi_spec_tools" not in text


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Infrastructure API files could get through without getting all imports updated.

## CHANGES
<!-- Please explain at a high-level the changes. -->

Fixed issue and tested.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->