### PR TITLE
Allow limiting API generation scope by specifying layout file

### DIFF
--- a/openapi_spec_tools/cli/api_gen.py
+++ b/openapi_spec_tools/cli/api_gen.py
@@ -14,9 +14,11 @@ from openapi_spec_tools.base_gen.files import set_copyright
 from openapi_spec_tools.cli._arguments import CopyrightFileOption
 from openapi_spec_tools.cli._arguments import LogLevelOption
 from openapi_spec_tools.cli._arguments import OpenApiFilenameArgument
-from openapi_spec_tools.cli._utils import get_logger
+from openapi_spec_tools.cli._arguments import StartPointOption
 from openapi_spec_tools.cli._utils import init_logging
+from openapi_spec_tools.cli._utils import layout_tree_with_error_handling
 from openapi_spec_tools.cli._utils import open_oas_with_error_handling
+from openapi_spec_tools.layout.layout_generator import DEFAULT_START
 from openapi_spec_tools.layout.layout_generator import LayoutGenerator
 
 SEP = "\n    "
@@ -44,17 +46,25 @@ def generate_api(
     copyright_file: CopyrightFileOption = None,
     prefix: Annotated[
         str,
-        typer.Option(show_default="", help="Prefix to ignore"),
+        typer.Option(show_default="", help="Prefix to ignore when using path"),
     ] = "",
+    layout_file: Annotated[
+        Optional[str],
+        typer.Option(show_default=False, help="Layout file name to use (instead of generating layout)")
+    ] = None,
+    start: StartPointOption = DEFAULT_START,
     log_level: LogLevelOption = "info",
 ) -> None:
     """Generate API code based on the provided parameters."""
-    init_logging(log_level, LOG_CLASS)
+    logger = init_logging(log_level, LOG_CLASS)
     code_dir = code_dir or package_name
 
-    oas = open_oas_with_error_handling(openapi_file, get_logger(LOG_CLASS))
-    layout_gen = LayoutGenerator()
-    commands = layout_gen.generate(oas, prefix)
+    oas = open_oas_with_error_handling(openapi_file, logger)
+    if layout_file:
+        commands = layout_tree_with_error_handling(layout_file, start, logger)
+    else:
+        layout_gen = LayoutGenerator()
+        commands = layout_gen.generate(oas, prefix)
 
     if copyright_file:
         text = Path(copyright_file).read_text()

--- a/tests/cli/test_api_gen.py
+++ b/tests/cli/test_api_gen.py
@@ -18,7 +18,7 @@ from tests.helpers import asset_filename
         pytest.param("sna", "sna", id="overrides"),
     ],
 )
-def test_api_generate_success(code_dir, expected_dir, temp_working_dir):
+def test_api_generate_success_directory(code_dir, expected_dir, temp_working_dir):
     oas_file = asset_filename("pet2.yaml")
     pkg_name = "my_api_pkg"
     base_dir = Path(temp_working_dir)
@@ -53,7 +53,8 @@ def test_api_generate_success(code_dir, expected_dir, temp_working_dir):
     assert filenames == expected
 
 
-def test_api_generate_success_copyright(copyright_fixture):
+@pytest.mark.usefixtures("copyright_fixture")
+def test_api_generate_success_copyright():
     oas_file = asset_filename("pet2.yaml")
 
     pkg_name = "my_api_pkg"
@@ -84,3 +85,48 @@ def test_api_generate_success_copyright(copyright_fixture):
         file = code_dir / fname
         text = read_text(file.as_posix())
         assert copyright_text in text
+
+
+@pytest.mark.parametrize(
+    ["layout", "expected_files"],
+    [
+        pytest.param(
+            None,
+            {
+                'examine_blood_pressure.py',
+                'examine_heart_rate.py',
+                'owners.py',
+                'owners_pets.py',
+                'pets.py',
+                'version.py',
+                'vets.py',
+            },
+            id="all",
+        ),
+        pytest.param(asset_filename("layout_pets.yaml"), {"main.py"}, id="layout"),
+    ],
+)
+def test_api_generate_success_layout(layout, expected_files, temp_working_dir):
+    oas_file = asset_filename("pets_and_vets.yaml")
+    pkg_name = "my_api_pkg"
+
+    with (
+        mock.patch('sys.stdout', new_callable=StringIo) as mock_stdout,
+    ):
+        generate_api(
+            oas_file,
+            pkg_name,
+            layout_file=layout,
+        )
+        assert "Generated API files\n" == mock_stdout.getvalue()
+
+    path = Path(temp_working_dir) / pkg_name
+    filenames = {i.name for i in path.iterdir()}
+    expected = {
+        "__init__.py",
+        "_environment.py",
+        "_logging.py",
+        "_requests.py",
+    }
+    expected.update(expected_files)
+    assert filenames == expected


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Allow using layout file to limit scope (and not generate layout).

## CHANGES
<!-- Please explain at a high-level the changes. -->

Added `api-gen` options to specify layout file. When specified, the layout file is used (so it can be reduced from the suggested layout).

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->