### PR TITLE
Avoid PytestCollectionWarning in test class

### DIFF
--- a/tests/api_gen/helpers.py
+++ b/tests/api_gen/helpers.py
@@ -3,6 +3,9 @@ from openapi_spec_tools.layout.types import LayoutNode
 
 
 class TestApiGenerator(ApiGenerator):
+    """Test class which implements the abstract function_definition() for test purposes."""
+    __test__ = False
+
     def function_definition(self, command: LayoutNode) -> str:
         return f"""
 def {self.function_name(command.identifier)}():


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Avoid warning when running tests by marking the `TestApiGenerator` class as not something being tested.


## CHANGES
<!-- Please explain at a high-level the changes. -->

Added `TestApiGenerator.__test__ = False`.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->