### PR TITLE
Add api-gen option to specify the request body handling

### DIFF
--- a/openapi_spec_tools/cli/api_gen.py
+++ b/openapi_spec_tools/cli/api_gen.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Implementation of the CLI generation CLI."""
 import os
+from enum import Enum
 from pathlib import Path
 from typing import Annotated
 from typing import Optional
@@ -10,6 +11,7 @@ import typer
 from openapi_spec_tools.api_gen.files import copy_api_infrastructure
 from openapi_spec_tools.api_gen.files import generate_api_node
 from openapi_spec_tools.api_gen.flat_generator import FlatApiGenerator
+from openapi_spec_tools.api_gen.opaque_generator import OpaqueApiGenerator
 from openapi_spec_tools.base_gen.files import set_copyright
 from openapi_spec_tools.cli._arguments import CopyrightFileOption
 from openapi_spec_tools.cli._arguments import LogLevelOption
@@ -24,6 +26,13 @@ from openapi_spec_tools.layout.layout_generator import LayoutGenerator
 SEP = "\n    "
 
 LOG_CLASS = "api-gen"
+
+class BodyType(str, Enum):
+    """Different body types for API generated code."""
+
+    FLAT = "flat"
+    OPAQUE = "opaque"
+
 
 #################################################
 # Top-level stuff
@@ -53,9 +62,14 @@ def generate_api(
         typer.Option(show_default=False, help="Layout file name to use (instead of generating layout)")
     ] = None,
     start: StartPointOption = DEFAULT_START,
+    body_type: Annotated[BodyType, typer.Option(help="Request body handling for API functions")] = BodyType.FLAT,
     log_level: LogLevelOption = "info",
 ) -> None:
-    """Generate API code based on the provided parameters."""
+    """Generate API code based on the provided parameters.
+
+    The body-type only applies to functions with a request body. It determines the granularity of
+    the function arguments, and the amount of work done to form the body.
+    """
     logger = init_logging(log_level, LOG_CLASS)
     code_dir = code_dir or package_name
 
@@ -81,7 +95,10 @@ def generate_api(
     # copy over the basic infrastructure
     copy_api_infrastructure(code_dir, package_name)
 
-    generator =FlatApiGenerator(package_name, oas, logger)
+    if body_type == BodyType.FLAT:
+        generator = FlatApiGenerator(package_name, oas, logger)
+    else:
+        generator = OpaqueApiGenerator(package_name, oas, logger)
     generate_api_node(generator, commands, code_dir)
 
     typer.echo("Generated API files")

--- a/tests/cli/test_api_gen.py
+++ b/tests/cli/test_api_gen.py
@@ -130,3 +130,36 @@ def test_api_generate_success_layout(layout, expected_files, temp_working_dir):
     }
     expected.update(expected_files)
     assert filenames == expected
+
+@pytest.mark.parametrize(
+    ["body_type", "expected"],
+    [
+        pytest.param(
+            "flat", [
+                'def create_pets(\n    id: int = None,',
+                'body["id"] = id',
+            ],
+            id="flat",
+        ),
+        pytest.param(
+            "opaque", [
+                'def create_pets(\n    body: Any = None,',
+            ],
+            id="opaque",
+        ),
+    ],
+)
+def test_api_generate_success_body_type(body_type, expected, temp_working_dir):
+    oas_file = asset_filename("pet.yaml")
+    pkg_name = "my_api_pkg"
+
+    generate_api(
+        oas_file,
+        pkg_name,
+        body_type=body_type,
+    )
+
+    file = Path(temp_working_dir) / pkg_name / "pets.py"
+    text = read_text(file.as_posix())
+    for item in expected:
+        assert item in text


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Provide users ability to control the granularity of request body arguments.

## CHANGES
<!-- Please explain at a high-level the changes. -->

Add `--body-type` option to allow user to specify which generator to use.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->