### PR TITLE
Fix issue with API generated standard arguments

### DIFF
--- a/examples/pets-api/pets_api/pets.py
+++ b/examples/pets-api/pets_api/pets.py
@@ -16,10 +16,10 @@ from pets_api import _requests as _r  # noqa: F401
 
 def list_pets(
     limit: Optional[int] = None,  # How many items to return at one time (max 100)
-    _api_host: str = _e.env_str("API_HOST", "http://petstore.swagger.io/v1"),  # host URL
-    _api_key: str = _e.env_str("API_KEY"),  # API key for bearer authentication
-    _api_timeout: int = _e.env("API_TIMEOUT", 5),  # timeout for operation
-    _log_level: str = _e.env("API_LOG_LEVEL", "info"),  # log level
+    _api_host: str = _e.env_string("API_HOST", "http://petstore.swagger.io/v1"),  # host URL
+    _api_key: str = _e.env_string("API_KEY"),  # API key for bearer authentication
+    _api_timeout: int = _e.env_int("API_TIMEOUT", 5),  # timeout for operation
+    _log_level: str = _e.env_string("API_LOG_LEVEL", "info"),  # log level
 ) -> Any:
     '''
     List all pets
@@ -42,10 +42,10 @@ def create_pets(
     name: str = None,
     tag: Optional[str] = None,
     owner: str = None,
-    _api_host: str = _e.env_str("API_HOST", "http://petstore.swagger.io/v1"),  # host URL
-    _api_key: str = _e.env_str("API_KEY"),  # API key for bearer authentication
-    _api_timeout: int = _e.env("API_TIMEOUT", 5),  # timeout for operation
-    _log_level: str = _e.env("API_LOG_LEVEL", "info"),  # log level
+    _api_host: str = _e.env_string("API_HOST", "http://petstore.swagger.io/v1"),  # host URL
+    _api_key: str = _e.env_string("API_KEY"),  # API key for bearer authentication
+    _api_timeout: int = _e.env_int("API_TIMEOUT", 5),  # timeout for operation
+    _log_level: str = _e.env_string("API_LOG_LEVEL", "info"),  # log level
 ) -> Any:
     '''
     Create a pet
@@ -69,10 +69,10 @@ def create_pets(
 
 def show_pet_by_id(
     pet_id: str,  # The id of the pet to retrieve
-    _api_host: str = _e.env_str("API_HOST", "http://petstore.swagger.io/v1"),  # host URL
-    _api_key: str = _e.env_str("API_KEY"),  # API key for bearer authentication
-    _api_timeout: int = _e.env("API_TIMEOUT", 5),  # timeout for operation
-    _log_level: str = _e.env("API_LOG_LEVEL", "info"),  # log level
+    _api_host: str = _e.env_string("API_HOST", "http://petstore.swagger.io/v1"),  # host URL
+    _api_key: str = _e.env_string("API_KEY"),  # API key for bearer authentication
+    _api_timeout: int = _e.env_int("API_TIMEOUT", 5),  # timeout for operation
+    _log_level: str = _e.env_string("API_LOG_LEVEL", "info"),  # log level
 ) -> Any:
     '''
     Info for a specific pet
@@ -90,10 +90,10 @@ def show_pet_by_id(
 
 def delete_pet_by_id(
     pet_id: str,  # The id of the pet to retrieve
-    _api_host: str = _e.env_str("API_HOST", "http://petstore.swagger.io/v1"),  # host URL
-    _api_key: str = _e.env_str("API_KEY"),  # API key for bearer authentication
-    _api_timeout: int = _e.env("API_TIMEOUT", 5),  # timeout for operation
-    _log_level: str = _e.env("API_LOG_LEVEL", "info"),  # log level
+    _api_host: str = _e.env_string("API_HOST", "http://petstore.swagger.io/v1"),  # host URL
+    _api_key: str = _e.env_string("API_KEY"),  # API key for bearer authentication
+    _api_timeout: int = _e.env_int("API_TIMEOUT", 5),  # timeout for operation
+    _log_level: str = _e.env_string("API_LOG_LEVEL", "info"),  # log level
 ) -> Any:
     '''
     Delete a pet

--- a/openapi_spec_tools/api_gen/api_generator.py
+++ b/openapi_spec_tools/api_gen/api_generator.py
@@ -63,10 +63,10 @@ from {self.package_name} import _requests as _r  # noqa: F401
     def command_infra_arguments(self, command: LayoutNode) -> list[str]:
         """Get the standard CLI function arguments to the command."""
         args = [
-            f'_api_host: str = _e.env_str({quoted(self.env_host)}, {quoted(self.default_host)}),  # host URL',
-            f'_api_key: str = _e.env_str({quoted(self.env_key)}),  # API key for bearer authentication',
-            f'_api_timeout: int = _e.env({quoted(self.env_timeout)}, 5),  # timeout for operation',
-            f'_log_level: str = _e.env({quoted(self.env_log_level)}, "info"),  # log level',
+            f'_api_host: str = _e.env_string({quoted(self.env_host)}, {quoted(self.default_host)}),  # host URL',
+            f'_api_key: str = _e.env_string({quoted(self.env_key)}),  # API key for bearer authentication',
+            f'_api_timeout: int = _e.env_int({quoted(self.env_timeout)}, 5),  # timeout for operation',
+            f'_log_level: str = _e.env_string({quoted(self.env_log_level)}, "info"),  # log level',
         ]
         return args
 

--- a/tests/api_gen/test_flat_generator.py
+++ b/tests/api_gen/test_flat_generator.py
@@ -49,10 +49,10 @@ def test_function_definition():
     assert '# handler for createPets: POST /pets' in text
 
     # check standard arguments
-    assert '_api_host: str = _e.env_str("API_HOST", "http://petstore.swagger.io/v1"),  # host URL' in text
-    assert '_api_key: str = _e.env_str("API_KEY"),  # API key for bearer authentication' in text
-    assert '_api_timeout: int = _e.env("API_TIMEOUT", 5),  # timeout for operation' in text
-    assert '_log_level: str = _e.env("API_LOG_LEVEL", "info"),  # log level' in text
+    assert '_api_host: str = _e.env_string("API_HOST", "http://petstore.swagger.io/v1"),  # host URL' in text
+    assert '_api_key: str = _e.env_string("API_KEY"),  # API key for bearer authentication' in text
+    assert '_api_timeout: int = _e.env_int("API_TIMEOUT", 5),  # timeout for operation' in text
+    assert '_log_level: str = _e.env_string("API_LOG_LEVEL", "info"),  # log level' in text
 
     # check the body of the function
     assert "_l.init_logging(_log_level)" in text
@@ -70,10 +70,10 @@ def test_function_deprecated():
     assert 'def snafoo_check(' in text
 
     # check a couple arguments
-    assert '_api_host: str = _e.env_str("API_HOST", "http://petstore.swagger.io/v1"),  # host URL' in text
-    assert '_api_key: str = _e.env_str("API_KEY"),  # API key for bearer authentication' in text
-    assert '_api_timeout: int = _e.env("API_TIMEOUT", 5),  # timeout for operation' in text
-    assert '_log_level: str = _e.env("API_LOG_LEVEL", "info"),  # log level' in text
+    assert '_api_host: str = _e.env_string("API_HOST", "http://petstore.swagger.io/v1"),  # host URL' in text
+    assert '_api_key: str = _e.env_string("API_KEY"),  # API key for bearer authentication' in text
+    assert '_api_timeout: int = _e.env_int("API_TIMEOUT", 5),  # timeout for operation' in text
+    assert '_log_level: str = _e.env_string("API_LOG_LEVEL", "info"),  # log level' in text
 
     # check the warning log
     assert '_l.logger().warning("snafooCheck is deprecated and should not be used.")' in text
@@ -88,10 +88,10 @@ def test_function_x_deprecated():
     assert 'def snafoo_delete(' in text
 
     # check a couple arguments
-    assert '_api_host: str = _e.env_str("API_HOST", "http://petstore.swagger.io/v1"),  # host URL' in text
-    assert '_api_key: str = _e.env_str("API_KEY"),  # API key for bearer authentication' in text
-    assert '_api_timeout: int = _e.env("API_TIMEOUT", 5),  # timeout for operation' in text
-    assert '_log_level: str = _e.env("API_LOG_LEVEL", "info"),  # log level' in text
+    assert '_api_host: str = _e.env_string("API_HOST", "http://petstore.swagger.io/v1"),  # host URL' in text
+    assert '_api_key: str = _e.env_string("API_KEY"),  # API key for bearer authentication' in text
+    assert '_api_timeout: int = _e.env_int("API_TIMEOUT", 5),  # timeout for operation' in text
+    assert '_log_level: str = _e.env_string("API_LOG_LEVEL", "info"),  # log level' in text
 
     # check the warning log
     assert '_l.logger().warning("snafooDelete was deprecated in 3.2.1, and should not be used.")' in text

--- a/tests/api_gen/test_opaque_generator.py
+++ b/tests/api_gen/test_opaque_generator.py
@@ -36,10 +36,10 @@ def test_function_definition():
     assert '# handler for createPets: POST /pets' in text
 
     # check standard arguments
-    assert '_api_host: str = _e.env_str("API_HOST", "http://petstore.swagger.io/v1"),  # host URL' in text
-    assert '_api_key: str = _e.env_str("API_KEY"),  # API key for bearer authentication' in text
-    assert '_api_timeout: int = _e.env("API_TIMEOUT", 5),  # timeout for operation' in text
-    assert '_log_level: str = _e.env("API_LOG_LEVEL", "info"),  # log level' in text
+    assert '_api_host: str = _e.env_string("API_HOST", "http://petstore.swagger.io/v1"),  # host URL' in text
+    assert '_api_key: str = _e.env_string("API_KEY"),  # API key for bearer authentication' in text
+    assert '_api_timeout: int = _e.env_int("API_TIMEOUT", 5),  # timeout for operation' in text
+    assert '_log_level: str = _e.env_string("API_LOG_LEVEL", "info"),  # log level' in text
 
     # check the body of the function
     assert "_l.init_logging(_log_level)" in text
@@ -57,10 +57,10 @@ def test_function_deprecated():
     assert 'def snafoo_check(' in text
 
     # check a couple arguments
-    assert '_api_host: str = _e.env_str("API_HOST", "http://petstore.swagger.io/v1"),  # host URL' in text
-    assert '_api_key: str = _e.env_str("API_KEY"),  # API key for bearer authentication' in text
-    assert '_api_timeout: int = _e.env("API_TIMEOUT", 5),  # timeout for operation' in text
-    assert '_log_level: str = _e.env("API_LOG_LEVEL", "info"),  # log level' in text
+    assert '_api_host: str = _e.env_string("API_HOST", "http://petstore.swagger.io/v1"),  # host URL' in text
+    assert '_api_key: str = _e.env_string("API_KEY"),  # API key for bearer authentication' in text
+    assert '_api_timeout: int = _e.env_int("API_TIMEOUT", 5),  # timeout for operation' in text
+    assert '_log_level: str = _e.env_string("API_LOG_LEVEL", "info"),  # log level' in text
 
     # check the warning log
     assert '_l.logger().warning("snafooCheck is deprecated and should not be used.")' in text
@@ -75,10 +75,10 @@ def test_function_x_deprecated():
     assert 'def snafoo_delete(' in text
 
     # check a couple arguments
-    assert '_api_host: str = _e.env_str("API_HOST", "http://petstore.swagger.io/v1"),  # host URL' in text
-    assert '_api_key: str = _e.env_str("API_KEY"),  # API key for bearer authentication' in text
-    assert '_api_timeout: int = _e.env("API_TIMEOUT", 5),  # timeout for operation' in text
-    assert '_log_level: str = _e.env("API_LOG_LEVEL", "info"),  # log level' in text
+    assert '_api_host: str = _e.env_string("API_HOST", "http://petstore.swagger.io/v1"),  # host URL' in text
+    assert '_api_key: str = _e.env_string("API_KEY"),  # API key for bearer authentication' in text
+    assert '_api_timeout: int = _e.env_int("API_TIMEOUT", 5),  # timeout for operation' in text
+    assert '_log_level: str = _e.env_string("API_LOG_LEVEL", "info"),  # log level' in text
 
     # check the warning log
     assert '_l.logger().warning("snafooDelete was deprecated in 3.2.1, and should not be used.")' in text


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Fix issue where the API calls were unusable due to calling the wrong `_enviroment` functions.

## CHANGES
<!-- Please explain at a high-level the changes. -->

Updated `ApiGenerator.command_infra_arguments()` to use the correct environment functions (and updated tests, too).

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->