### PR TITLE
Allow for unspecified default in API environment functions

### DIFF
--- a/examples/pets-api/pets_api/_environment.py
+++ b/examples/pets-api/pets_api/_environment.py
@@ -6,7 +6,7 @@ import os
 from typing import Optional
 
 
-def env_string(varname: str, default: Optional[str], except_missing: bool = False) -> Optional[str]:
+def env_string(varname: str, default: Optional[str] = None, except_missing: bool = False) -> Optional[str]:
     value = os.environ.get(varname)
     if value is not None:
         return value
@@ -15,7 +15,7 @@ def env_string(varname: str, default: Optional[str], except_missing: bool = Fals
     return default
 
 
-def env_int(varname: str, default: Optional[int], except_missing: bool = False) -> Optional[int]:
+def env_int(varname: str, default: Optional[int] = None, except_missing: bool = False) -> Optional[int]:
     value = os.environ.get(varname)
     if value is not None:
         return int(value)

--- a/openapi_spec_tools/api_gen/_environment.py
+++ b/openapi_spec_tools/api_gen/_environment.py
@@ -2,7 +2,7 @@ import os
 from typing import Optional
 
 
-def env_string(varname: str, default: Optional[str], except_missing: bool = False) -> Optional[str]:
+def env_string(varname: str, default: Optional[str] = None, except_missing: bool = False) -> Optional[str]:
     value = os.environ.get(varname)
     if value is not None:
         return value
@@ -11,7 +11,7 @@ def env_string(varname: str, default: Optional[str], except_missing: bool = Fals
     return default
 
 
-def env_int(varname: str, default: Optional[int], except_missing: bool = False) -> Optional[int]:
+def env_int(varname: str, default: Optional[int] = None, except_missing: bool = False) -> Optional[int]:
     value = os.environ.get(varname)
     if value is not None:
         return int(value)

--- a/tests/api_gen/test_environment.py
+++ b/tests/api_gen/test_environment.py
@@ -1,0 +1,60 @@
+import os
+from unittest import mock
+
+import pytest
+
+from openapi_spec_tools.api_gen._environment import env_int
+from openapi_spec_tools.api_gen._environment import env_string
+
+
+@pytest.mark.parametrize(
+    ["alternate", "args", "expected"],
+    [
+        pytest.param({"FOO": "sna"}, ["FOO", "bar"], "sna", id="env"),
+        pytest.param({}, ["FOO", "bar"], "bar", id="default"),
+        pytest.param({}, ["FOO"], None, id="none"),
+    ]
+)
+def test_env_string_success(alternate, args, expected):
+    with mock.patch.dict(os.environ, alternate, clear=True):
+        assert expected == env_string(*args)
+
+
+def test_env_string_missing():
+    alternate = {}
+    with (
+        mock.patch.dict(os.environ, alternate, clear=True),
+        pytest.raises(ValueError, match="Missing FOO value"),
+    ):
+        env_string("FOO", "bar", True)
+
+
+@pytest.mark.parametrize(
+    ["alternate", "args", "expected"],
+    [
+        pytest.param({"FOO": "17"}, ["FOO", 25], 17, id="env"),
+        pytest.param({}, ["FOO", 23], 23, id="default"),
+        pytest.param({}, ["FOO"], None, id="none"),
+    ]
+)
+def test_env_int_success(alternate, args, expected):
+    with mock.patch.dict(os.environ, alternate, clear=True):
+        assert expected == env_int(*args)
+
+
+def test_env_int_missing():
+    alternate = {}
+    with (
+        mock.patch.dict(os.environ, alternate, clear=True),
+        pytest.raises(ValueError, match="Missing FOO value"),
+    ):
+        env_int("FOO", 5, True)
+
+
+def test_env_int_bad_value():
+    alternate = {"FOO": "silly"}
+    with (
+        mock.patch.dict(os.environ, alternate, clear=True),
+        pytest.raises(ValueError),
+    ):
+        env_int("FOO", 55, True)


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

User should not need to specify the default value for environment functions.

## CHANGES
<!-- Please explain at a high-level the changes. -->

Allow for unspecified default values in `env_string()` and `env_int()`.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->