### PR TITLE
Use lazy API argument initialization

### DIFF
--- a/examples/pets-api/pets_api/pets.py
+++ b/examples/pets-api/pets_api/pets.py
@@ -16,15 +16,20 @@ from pets_api import _requests as _r  # noqa: F401
 
 def list_pets(
     limit: Optional[int] = None,  # How many items to return at one time (max 100)
-    _api_host: str = _e.env_string("API_HOST", "http://petstore.swagger.io/v1"),  # host URL
-    _api_key: str = _e.env_string("API_KEY"),  # API key for bearer authentication
-    _api_timeout: int = _e.env_int("API_TIMEOUT", 5),  # timeout for operation
-    _log_level: str = _e.env_string("API_LOG_LEVEL", "info"),  # log level
+    _api_host: Optional[str] = None,  # API host, read from API_HOST if not provided, defaults to http://petstore.swagger.io/v1
+    _api_key: Optional[str] = None,  # API key for bearer auth, read from API_KEY if not provided
+    _api_timeout: Optional[int] = None,  # timeout for operation, read from API_TIMEOUT if not provided, defaults to 5
+    _log_level: Optional[str] = None,  # log level, read from API_LOG_LEVEL if not provided, defaults to info
 ) -> Any:
     '''
     List all pets
     '''
     # handler for listPets: GET /pets
+    _api_host = _api_host or _e.env_string("API_HOST", default="http://petstore.swagger.io/v1", except_missing=True)
+    _api_key = _api_key or _e.env_string("API_KEY", except_missing=True)
+    _api_timeout = _api_timeout or _e.env_int("API_TIMEOUT", default=5)
+    _log_level = _log_level or _e.env_string("API_LOG_LEVEL", default="info")
+
     _l.init_logging(_log_level)
     headers = _r.request_headers(_api_key)
     url = _r.create_url(_api_host, "pets")
@@ -42,15 +47,20 @@ def create_pets(
     name: str = None,
     tag: Optional[str] = None,
     owner: str = None,
-    _api_host: str = _e.env_string("API_HOST", "http://petstore.swagger.io/v1"),  # host URL
-    _api_key: str = _e.env_string("API_KEY"),  # API key for bearer authentication
-    _api_timeout: int = _e.env_int("API_TIMEOUT", 5),  # timeout for operation
-    _log_level: str = _e.env_string("API_LOG_LEVEL", "info"),  # log level
+    _api_host: Optional[str] = None,  # API host, read from API_HOST if not provided, defaults to http://petstore.swagger.io/v1
+    _api_key: Optional[str] = None,  # API key for bearer auth, read from API_KEY if not provided
+    _api_timeout: Optional[int] = None,  # timeout for operation, read from API_TIMEOUT if not provided, defaults to 5
+    _log_level: Optional[str] = None,  # log level, read from API_LOG_LEVEL if not provided, defaults to info
 ) -> Any:
     '''
     Create a pet
     '''
     # handler for createPets: POST /pets
+    _api_host = _api_host or _e.env_string("API_HOST", default="http://petstore.swagger.io/v1", except_missing=True)
+    _api_key = _api_key or _e.env_string("API_KEY", except_missing=True)
+    _api_timeout = _api_timeout or _e.env_int("API_TIMEOUT", default=5)
+    _log_level = _log_level or _e.env_string("API_LOG_LEVEL", default="info")
+
     _l.init_logging(_log_level)
     headers = _r.request_headers(_api_key, content_type="application/json")
     url = _r.create_url(_api_host, "pets")
@@ -69,15 +79,20 @@ def create_pets(
 
 def show_pet_by_id(
     pet_id: str,  # The id of the pet to retrieve
-    _api_host: str = _e.env_string("API_HOST", "http://petstore.swagger.io/v1"),  # host URL
-    _api_key: str = _e.env_string("API_KEY"),  # API key for bearer authentication
-    _api_timeout: int = _e.env_int("API_TIMEOUT", 5),  # timeout for operation
-    _log_level: str = _e.env_string("API_LOG_LEVEL", "info"),  # log level
+    _api_host: Optional[str] = None,  # API host, read from API_HOST if not provided, defaults to http://petstore.swagger.io/v1
+    _api_key: Optional[str] = None,  # API key for bearer auth, read from API_KEY if not provided
+    _api_timeout: Optional[int] = None,  # timeout for operation, read from API_TIMEOUT if not provided, defaults to 5
+    _log_level: Optional[str] = None,  # log level, read from API_LOG_LEVEL if not provided, defaults to info
 ) -> Any:
     '''
     Info for a specific pet
     '''
     # handler for showPetById: GET /pets/{petId}
+    _api_host = _api_host or _e.env_string("API_HOST", default="http://petstore.swagger.io/v1", except_missing=True)
+    _api_key = _api_key or _e.env_string("API_KEY", except_missing=True)
+    _api_timeout = _api_timeout or _e.env_int("API_TIMEOUT", default=5)
+    _log_level = _log_level or _e.env_string("API_LOG_LEVEL", default="info")
+
     _l.init_logging(_log_level)
     headers = _r.request_headers(_api_key)
     url = _r.create_url(_api_host, "pets", pet_id)
@@ -90,15 +105,20 @@ def show_pet_by_id(
 
 def delete_pet_by_id(
     pet_id: str,  # The id of the pet to retrieve
-    _api_host: str = _e.env_string("API_HOST", "http://petstore.swagger.io/v1"),  # host URL
-    _api_key: str = _e.env_string("API_KEY"),  # API key for bearer authentication
-    _api_timeout: int = _e.env_int("API_TIMEOUT", 5),  # timeout for operation
-    _log_level: str = _e.env_string("API_LOG_LEVEL", "info"),  # log level
+    _api_host: Optional[str] = None,  # API host, read from API_HOST if not provided, defaults to http://petstore.swagger.io/v1
+    _api_key: Optional[str] = None,  # API key for bearer auth, read from API_KEY if not provided
+    _api_timeout: Optional[int] = None,  # timeout for operation, read from API_TIMEOUT if not provided, defaults to 5
+    _log_level: Optional[str] = None,  # log level, read from API_LOG_LEVEL if not provided, defaults to info
 ) -> Any:
     '''
     Delete a pet
     '''
     # handler for deletePetById: DELETE /pets/{petId}
+    _api_host = _api_host or _e.env_string("API_HOST", default="http://petstore.swagger.io/v1", except_missing=True)
+    _api_key = _api_key or _e.env_string("API_KEY", except_missing=True)
+    _api_timeout = _api_timeout or _e.env_int("API_TIMEOUT", default=5)
+    _log_level = _log_level or _e.env_string("API_LOG_LEVEL", default="info")
+
     _l.init_logging(_log_level)
     headers = _r.request_headers(_api_key)
     url = _r.create_url(_api_host, "pets", pet_id)

--- a/openapi_spec_tools/api_gen/api_generator.py
+++ b/openapi_spec_tools/api_gen/api_generator.py
@@ -11,6 +11,7 @@ from typing import Optional
 
 from openapi_spec_tools.base_gen.base_generator import BaseGenerator
 from openapi_spec_tools.base_gen.constants import COLLECTIONS
+from openapi_spec_tools.base_gen.constants import SEP1
 from openapi_spec_tools.base_gen.utils import maybe_quoted
 from openapi_spec_tools.base_gen.utils import quoted
 from openapi_spec_tools.base_gen.utils import simple_escape
@@ -34,6 +35,8 @@ class ApiGenerator(BaseGenerator, ABC):
         self.env_key = "API_KEY"
         self.env_timeout = "API_TIMEOUT"
         self.env_log_level = "API_LOG_LEVEL"
+        self.default_log = "info"
+        self.default_timeout = 5
 
     def property_help(self, prop: dict[str, Any]) -> str:
         """Get the short help string for the specified property."""
@@ -60,13 +63,38 @@ from {self.package_name} import _logging as _l  # noqa: F401
 from {self.package_name} import _requests as _r  # noqa: F401
 """
 
+    def init_infra_args(self, operation: dict[str, Any]) -> str:
+        """Provide initialization of standard arguments inside body."""
+        host_default = (
+            f'_e.env_string({quoted(self.env_host)}, '
+            f'default={quoted(self.default_host)}, except_missing=True)'
+        )
+        key_default = f'_e.env_string({quoted(self.env_key)}, except_missing=True)'
+        timeout_default = f'_e.env_int({quoted(self.env_timeout)}, default={self.default_timeout})'
+        log_default = f'_e.env_string({quoted(self.env_log_level)}, default={quoted(self.default_log)})'
+        lines = [
+            f'_api_host = _api_host or {host_default}',
+            f'_api_key = _api_key or {key_default}',
+            f'_api_timeout = _api_timeout or {timeout_default}',
+            f'_log_level = _log_level or {log_default}',
+        ]
+        return SEP1.join(lines)
+
+
     def command_infra_arguments(self, command: LayoutNode) -> list[str]:
         """Get the standard CLI function arguments to the command."""
+        host_help = f'API host, read from {self.env_host} if not provided, defaults to {self.default_host}'
+        key_help = f'API key for bearer auth, read from {self.env_key} if not provided'
+        timeout_help = (
+            f'timeout for operation, read from {self.env_timeout} if not provided, '
+            f'defaults to {self.default_timeout}'
+        )
+        log_help = f'log level, read from {self.env_log_level} if not provided, defaults to {self.default_log}'
         args = [
-            f'_api_host: str = _e.env_string({quoted(self.env_host)}, {quoted(self.default_host)}),  # host URL',
-            f'_api_key: str = _e.env_string({quoted(self.env_key)}),  # API key for bearer authentication',
-            f'_api_timeout: int = _e.env_int({quoted(self.env_timeout)}, 5),  # timeout for operation',
-            f'_log_level: str = _e.env_string({quoted(self.env_log_level)}, "info"),  # log level',
+            f'_api_host: Optional[str] = None,  # {host_help}',
+            f'_api_key: Optional[str] = None,  # {key_help}',
+            f'_api_timeout: Optional[int] = None,  # {timeout_help}',
+            f'_log_level: Optional[str] = None,  # {log_help}',
         ]
         return args
 

--- a/openapi_spec_tools/api_gen/flat_generator.py
+++ b/openapi_spec_tools/api_gen/flat_generator.py
@@ -90,6 +90,8 @@ class FlatApiGenerator(ApiGenerator):
 {self.enum_definitions(path_params, query_params + header_params, body_params)}
 def {func_name}({args_str}) -> Any:
     {self.op_doc_string(op)}# handler for {node.identifier}: {method} {path}
+    {self.init_infra_args(op)}
+
     _l.init_logging(_log_level){deprecation_warning}{user_header_init}
     headers = _r.request_headers(_api_key{self.op_content_header(op)}{user_header_arg})
     url = _r.create_url({self.op_url_params(path)})

--- a/openapi_spec_tools/api_gen/opaque_generator.py
+++ b/openapi_spec_tools/api_gen/opaque_generator.py
@@ -95,6 +95,8 @@ class OpaqueApiGenerator(ApiGenerator):
 {self.enum_definitions(path_params, query_params + header_params, {})}
 def {func_name}({args_str}) -> Any:
     {self.op_doc_string(op)}# handler for {node.identifier}: {method} {path}
+    {self.init_infra_args(op)}
+
     _l.init_logging(_log_level){deprecation_warning}{user_header_init}
     headers = _r.request_headers(_api_key{self.op_content_header(op)}{user_header_arg})
     url = _r.create_url({self.op_url_params(path)})

--- a/tests/api_gen/test_flat_generator.py
+++ b/tests/api_gen/test_flat_generator.py
@@ -48,11 +48,17 @@ def test_function_definition():
     assert 'def create_pets(' in text
     assert '# handler for createPets: POST /pets' in text
 
-    # check standard arguments
-    assert '_api_host: str = _e.env_string("API_HOST", "http://petstore.swagger.io/v1"),  # host URL' in text
-    assert '_api_key: str = _e.env_string("API_KEY"),  # API key for bearer authentication' in text
-    assert '_api_timeout: int = _e.env_int("API_TIMEOUT", 5),  # timeout for operation' in text
-    assert '_log_level: str = _e.env_string("API_LOG_LEVEL", "info"),  # log level' in text
+    # check infra arguments
+    assert '_api_host: Optional[str] = None,' in text
+    assert '_api_key: Optional[str] = None,' in text
+    assert '_api_timeout: Optional[int] = None,' in text
+    assert '_log_level: Optional[str] = None,' in text
+
+    # check infra initialization/defaults
+    assert '_api_host = _api_host or _e.env_string("API_HOST"' in text
+    assert '_api_key = _api_key or _e.env_string("API_KEY"' in text
+    assert '_api_timeout = _api_timeout or _e.env_int("API_TIMEOUT"' in text
+    assert '_log_level = _log_level or _e.env_string("API_LOG_LEVEL"' in text
 
     # check the body of the function
     assert "_l.init_logging(_log_level)" in text
@@ -69,11 +75,11 @@ def test_function_deprecated():
 
     assert 'def snafoo_check(' in text
 
-    # check a couple arguments
-    assert '_api_host: str = _e.env_string("API_HOST", "http://petstore.swagger.io/v1"),  # host URL' in text
-    assert '_api_key: str = _e.env_string("API_KEY"),  # API key for bearer authentication' in text
-    assert '_api_timeout: int = _e.env_int("API_TIMEOUT", 5),  # timeout for operation' in text
-    assert '_log_level: str = _e.env_string("API_LOG_LEVEL", "info"),  # log level' in text
+    # check infra arguments
+    assert '_api_host: Optional[str] = None,' in text
+    assert '_api_key: Optional[str] = None,' in text
+    assert '_api_timeout: Optional[int] = None,' in text
+    assert '_log_level: Optional[str] = None,' in text
 
     # check the warning log
     assert '_l.logger().warning("snafooCheck is deprecated and should not be used.")' in text
@@ -87,11 +93,11 @@ def test_function_x_deprecated():
 
     assert 'def snafoo_delete(' in text
 
-    # check a couple arguments
-    assert '_api_host: str = _e.env_string("API_HOST", "http://petstore.swagger.io/v1"),  # host URL' in text
-    assert '_api_key: str = _e.env_string("API_KEY"),  # API key for bearer authentication' in text
-    assert '_api_timeout: int = _e.env_int("API_TIMEOUT", 5),  # timeout for operation' in text
-    assert '_log_level: str = _e.env_string("API_LOG_LEVEL", "info"),  # log level' in text
+    # check infra arguments
+    assert '_api_host: Optional[str] = None,' in text
+    assert '_api_key: Optional[str] = None,' in text
+    assert '_api_timeout: Optional[int] = None,' in text
+    assert '_log_level: Optional[str] = None,' in text
 
     # check the warning log
     assert '_l.logger().warning("snafooDelete was deprecated in 3.2.1, and should not be used.")' in text

--- a/tests/api_gen/test_opaque_generator.py
+++ b/tests/api_gen/test_opaque_generator.py
@@ -35,11 +35,17 @@ def test_function_definition():
     assert 'def create_pets(' in text
     assert '# handler for createPets: POST /pets' in text
 
-    # check standard arguments
-    assert '_api_host: str = _e.env_string("API_HOST", "http://petstore.swagger.io/v1"),  # host URL' in text
-    assert '_api_key: str = _e.env_string("API_KEY"),  # API key for bearer authentication' in text
-    assert '_api_timeout: int = _e.env_int("API_TIMEOUT", 5),  # timeout for operation' in text
-    assert '_log_level: str = _e.env_string("API_LOG_LEVEL", "info"),  # log level' in text
+    # check infra arguments
+    assert '_api_host: Optional[str] = None,' in text
+    assert '_api_key: Optional[str] = None,' in text
+    assert '_api_timeout: Optional[int] = None,' in text
+    assert '_log_level: Optional[str] = None,' in text
+
+    # check infra initialization/defaults
+    assert '_api_host = _api_host or _e.env_string("API_HOST"' in text
+    assert '_api_key = _api_key or _e.env_string("API_KEY"' in text
+    assert '_api_timeout = _api_timeout or _e.env_int("API_TIMEOUT"' in text
+    assert '_log_level = _log_level or _e.env_string("API_LOG_LEVEL"' in text
 
     # check the body of the function
     assert "_l.init_logging(_log_level)" in text
@@ -56,11 +62,11 @@ def test_function_deprecated():
 
     assert 'def snafoo_check(' in text
 
-    # check a couple arguments
-    assert '_api_host: str = _e.env_string("API_HOST", "http://petstore.swagger.io/v1"),  # host URL' in text
-    assert '_api_key: str = _e.env_string("API_KEY"),  # API key for bearer authentication' in text
-    assert '_api_timeout: int = _e.env_int("API_TIMEOUT", 5),  # timeout for operation' in text
-    assert '_log_level: str = _e.env_string("API_LOG_LEVEL", "info"),  # log level' in text
+    # check infra arguments
+    assert '_api_host: Optional[str] = None,' in text
+    assert '_api_key: Optional[str] = None,' in text
+    assert '_api_timeout: Optional[int] = None,' in text
+    assert '_log_level: Optional[str] = None,' in text
 
     # check the warning log
     assert '_l.logger().warning("snafooCheck is deprecated and should not be used.")' in text
@@ -74,11 +80,11 @@ def test_function_x_deprecated():
 
     assert 'def snafoo_delete(' in text
 
-    # check a couple arguments
-    assert '_api_host: str = _e.env_string("API_HOST", "http://petstore.swagger.io/v1"),  # host URL' in text
-    assert '_api_key: str = _e.env_string("API_KEY"),  # API key for bearer authentication' in text
-    assert '_api_timeout: int = _e.env_int("API_TIMEOUT", 5),  # timeout for operation' in text
-    assert '_log_level: str = _e.env_string("API_LOG_LEVEL", "info"),  # log level' in text
+    # check infra arguments
+    assert '_api_host: Optional[str] = None,' in text
+    assert '_api_key: Optional[str] = None,' in text
+    assert '_api_timeout: Optional[int] = None,' in text
+    assert '_log_level: Optional[str] = None,' in text
 
     # check the warning log
     assert '_l.logger().warning("snafooDelete was deprecated in 3.2.1, and should not be used.")' in text


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Using lazy initialization allows users to change environment values while the module is loaded. Otherwise, a change in environment variable means the default values do NOT pick up the new value -- the default is only initialized once when the module loads.

## CHANGES
<!-- Please explain at a high-level the changes. -->

Default all the infrastructure arguments to `None`, and initialize them inside the body of the functions.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->