### PR TITLE
Generate layout when none provided for 'cli-gen generate'

### DIFF
--- a/examples/cloudtruth-gen-cli/Makefile
+++ b/examples/cloudtruth-gen-cli/Makefile
@@ -32,7 +32,7 @@ layout-lint:  ## Check the layout file format
 	$(poetry_run) layout check $(LAYOUT_FILE)
 
 gen: layout-lint ## Generate CLI code
-	$(poetry_run) cli-gen generate $(LAYOUT_FILE) $(OPENAPI_SPEC) $(PACKAGE_NAME) --project-dir $(PROJECT_DIRECTORY) --no-tests
+	$(poetry_run) cli-gen generate $(OPENAPI_SPEC) $(PACKAGE_NAME) --layout-file $(LAYOUT_FILE) --project-dir $(PROJECT_DIRECTORY) --no-tests
 
 missing: ## Print the OAS operations not in the layout
 	$(poetry_run) cli-gen unreferenced $(LAYOUT_FILE) $(OPENAPI_SPEC)

--- a/examples/github/Makefile
+++ b/examples/github/Makefile
@@ -37,7 +37,7 @@ trim: ## Creates the skinny OpenAPI spec
 	$(poetry_run) cli-gen trim $(LAYOUT_FILE) $(OPENAPI_SPEC) --updated-file $(TRIMMED_SPEC) --remove examples
 
 gen: layout-lint trim ## Generate CLI code
-	$(poetry_run) cli-gen generate $(LAYOUT_FILE) $(TRIMMED_SPEC) $(PACKAGE_NAME) --project-dir $(PROJECT_DIRECTORY) --no-tests
+	$(poetry_run) cli-gen generate $(TRIMMED_SPEC) $(PACKAGE_NAME) --layout-file $(LAYOUT_FILE) --project-dir $(PROJECT_DIRECTORY) --no-tests
 
 missing: ## Print the OAS operations not in the layout
 	$(poetry_run) cli-gen unreferenced $(LAYOUT_FILE) $(OPENAPI_SPEC)

--- a/examples/pets-cli/Makefile
+++ b/examples/pets-cli/Makefile
@@ -38,7 +38,7 @@ layout-suggest: ## Create suggested layout file
 	$(poetry_run) layout suggest $(OPENAPI_SPEC) $(SUGGESTED_FILE) --prefix /pets
 
 cli-gen: layout-lint ## Generate CLI code
-	$(poetry_run) cli-gen generate $(LAYOUT_FILE) $(OPENAPI_SPEC) $(PACKAGE_NAME) --project-dir $(PROJECT_DIRECTORY)
+	$(poetry_run) cli-gen generate $(OPENAPI_SPEC) $(PACKAGE_NAME) --layout-file $(LAYOUT_FILE) --project-dir $(PROJECT_DIRECTORY)
 
 missing: ## Print the OAS operations not in the layout
 	$(poetry_run) cli-gen unreferenced $(LAYOUT_FILE) $(OPENAPI_SPEC)

--- a/openapi_spec_tools/cli/_arguments.py
+++ b/openapi_spec_tools/cli/_arguments.py
@@ -32,7 +32,7 @@ CopyrightFileOption = Annotated[
 ]
 LayoutFilenameArgument = Annotated[
     str,
-    typer.Argument(metavar=FILENAME, show_default=False , help="Layout file YAML definition"),
+    typer.Argument(metavar=FILENAME, show_default=False, help="Layout file YAML definition"),
 ]
 LayoutFilenameOption = Annotated[
     Optional[str],
@@ -56,6 +56,10 @@ OpenApiFilenameArgument = Annotated[
     typer.Argument(metavar=FILENAME, show_default=False, help="OpenAPI specification filename"),
 ]
 PackageNameArgument = Annotated[str, typer.Argument(metavar="PACKAGE", show_default=False, help="Base package name")]
+PathPrefixOption = Annotated[
+    str,
+    typer.Option(metavar="PREFIX", show_default=False, help="Prefix to ignore when using path"),
+]
 StartPointOption = Annotated[str, typer.Option("--start", metavar="START", help="Start point for CLI in layout file")]
 UpdatedOpenApiFilenameOption = Annotated[
     Optional[str],

--- a/openapi_spec_tools/cli/api_gen.py
+++ b/openapi_spec_tools/cli/api_gen.py
@@ -18,6 +18,7 @@ from openapi_spec_tools.cli._arguments import LayoutFilenameOption
 from openapi_spec_tools.cli._arguments import LogLevelOption
 from openapi_spec_tools.cli._arguments import OpenApiFilenameArgument
 from openapi_spec_tools.cli._arguments import PackageNameArgument
+from openapi_spec_tools.cli._arguments import PathPrefixOption
 from openapi_spec_tools.cli._arguments import StartPointOption
 from openapi_spec_tools.cli._utils import init_logging
 from openapi_spec_tools.cli._utils import layout_tree_with_error_handling
@@ -52,10 +53,7 @@ def generate_api(
     package_name: PackageNameArgument,
     code_dir: CodeDirectoryOption = None,
     copyright_file: CopyrightFileOption = None,
-    prefix: Annotated[
-        str,
-        typer.Option(show_default="", help="Prefix to ignore when using path"),
-    ] = "",
+    prefix: PathPrefixOption = "",
     layout_file: LayoutFilenameOption = None,
     start: StartPointOption = DEFAULT_START,
     body_type: Annotated[BodyType, typer.Option(help="Request body handling for API functions")] = BodyType.FLAT,

--- a/openapi_spec_tools/cli/cli_gen.py
+++ b/openapi_spec_tools/cli/cli_gen.py
@@ -13,9 +13,11 @@ from openapi_spec_tools.base_gen.files import set_copyright
 from openapi_spec_tools.cli._arguments import CodeDirectoryOption
 from openapi_spec_tools.cli._arguments import CopyrightFileOption
 from openapi_spec_tools.cli._arguments import LayoutFilenameArgument
+from openapi_spec_tools.cli._arguments import LayoutFilenameOption
 from openapi_spec_tools.cli._arguments import LogLevelOption
 from openapi_spec_tools.cli._arguments import OpenApiFilenameArgument
 from openapi_spec_tools.cli._arguments import PackageNameArgument
+from openapi_spec_tools.cli._arguments import PathPrefixOption
 from openapi_spec_tools.cli._arguments import StartPointOption
 from openapi_spec_tools.cli._arguments import UpdatedOpenApiFilenameOption
 from openapi_spec_tools.cli._utils import console_factory
@@ -32,6 +34,7 @@ from openapi_spec_tools.cli_gen.files import find_unreferenced
 from openapi_spec_tools.cli_gen.files import generate_node
 from openapi_spec_tools.cli_gen.files import generate_tree_file
 from openapi_spec_tools.cli_gen.files import generate_tree_node
+from openapi_spec_tools.layout.layout_generator import LayoutGenerator
 from openapi_spec_tools.layout.types import LayoutNode
 from openapi_spec_tools.layout.utils import DEFAULT_START
 from openapi_spec_tools.types import OasField
@@ -68,9 +71,9 @@ def render_missing(missing: dict[str, list[str]]) -> str:
 
 @app.command("generate", short_help="Generate CLI code")
 def generate_cli(
-    layout_file: LayoutFilenameArgument,
     openapi_file: OpenApiFilenameArgument,
     package_name: PackageNameArgument,
+    layout_file: LayoutFilenameOption = None,
     project_dir: Annotated[
         Optional[str],
         typer.Option(metavar=DIRECTORY, show_default=False, help="Project directory name")
@@ -82,6 +85,7 @@ def generate_cli(
     ] = None,
     copyright_file: CopyrightFileOption = None,
     include_tests: Annotated[bool, typer.Option("--tests/--no-tests", help="Include tests in generated coode")] = True,
+    prefix: PathPrefixOption = "",
     start: StartPointOption = DEFAULT_START,
     log_level: LogLevelOption = "info",
 ) -> None:
@@ -109,17 +113,22 @@ def generate_cli(
             )
             raise typer.Exit(1)
 
-    commands = layout_tree_with_error_handling(layout_file, start=start, logger=logger)
-    oas = open_oas_with_error_handling(openapi_file, logger)
-
     if copyright_file:
         text = Path(copyright_file).read_text()
         set_copyright(text)
 
-    missing = check_for_missing(commands, oas)
-    if missing:
-        typer.echo(render_missing(missing))
-        raise typer.Exit(1)
+    oas = open_oas_with_error_handling(openapi_file, logger)
+    if layout_file:
+        commands = layout_tree_with_error_handling(layout_file, start, logger)
+
+        missing = check_for_missing(commands, oas)
+        if missing:
+            typer.echo(render_missing(missing))
+            raise typer.Exit(1)
+    else:
+        layout_gen = LayoutGenerator()
+        commands = layout_gen.generate(oas, prefix)
+        typer.echo("Generated layout -- equivalent can be saved using 'layout suggest'.")
 
     os.makedirs(code_dir, exist_ok=True)
 

--- a/openapi_spec_tools/cli/layout.py
+++ b/openapi_spec_tools/cli/layout.py
@@ -13,6 +13,7 @@ from rich.table import Table
 from openapi_spec_tools.cli._arguments import LayoutFilenameArgument
 from openapi_spec_tools.cli._arguments import LogLevelOption
 from openapi_spec_tools.cli._arguments import OpenApiFilenameArgument
+from openapi_spec_tools.cli._arguments import PathPrefixOption
 from openapi_spec_tools.cli._arguments import StartPointOption
 from openapi_spec_tools.cli._utils import console_factory
 from openapi_spec_tools.cli._utils import init_logging
@@ -191,8 +192,8 @@ def layout_operations(
 )
 def layout_suggest(
     openapi_file: OpenApiFilenameArgument,
-    output_file: Annotated[str, typer.Argument(show_default=False, help="File name for output")],
-    prefix: Annotated[str, typer.Option(show_default=False, help="Prefix common to all paths")] = "",
+    output_file: Annotated[str, typer.Argument(metavar="FILENAME", show_default=False, help="File name for output")],
+    prefix: PathPrefixOption = "",
     log_level: LogLevelOption = "info",
 ) -> None:
     """Create a suggested layout based on the OpenAPI spec paths and operations.

--- a/tests/cli/test_cli_gen.py
+++ b/tests/cli/test_cli_gen.py
@@ -48,9 +48,9 @@ def test_cli_generate_success(code_dir, test_dir, include_tests, expected_code, 
         mock.patch('sys.stdout', new_callable=StringIo) as mock_stdout,
     ):
         generate_cli(
-            layout_file,
             oas_file,
             pkg_name,
+            layout_file=layout_file,
             project_dir=directory.name,
             code_dir=code_path,
             test_dir=test_path,
@@ -118,9 +118,9 @@ def test_cli_generate_success_copyright(copyright_fixture):
 
     with mock.patch('sys.stdout', new_callable=StringIo) as mock_stdout:
         generate_cli(
-            layout_file,
             oas_file,
             pkg_name,
+            layout_file=layout_file,
             project_dir=directory.name,
             include_tests=True,
             copyright_file=copyright_file.as_posix()
@@ -161,6 +161,41 @@ def test_cli_generate_success_copyright(copyright_fixture):
         assert copyright_text in text
 
 
+def test_cli_generate_success_no_layout():
+    oas_file = asset_filename("pet2.yaml")
+
+    pkg_name = "my_cli_pkg"
+    directory = TemporaryDirectory()
+    base_dir = Path(directory.name)
+
+    with mock.patch('sys.stdout', new_callable=StringIo) as mock_stdout:
+        generate_cli(
+            oas_file,
+            pkg_name,
+            project_dir=directory.name,
+            prefix="/pets"
+        )
+        text = mock_stdout.getvalue()
+        assert "Generated layout -- equivalent can be saved using 'layout suggest'" in text
+        assert "Generated files" in text
+
+    filenames = {
+        "__init__.py",
+        "_arguments.py",
+        "_console.py",
+        "_display.py",
+        "_exceptions.py",
+        "_logging.py",
+        "_requests.py",
+        "_tree.py",
+        "main.py",
+        "tree.yaml",
+    }
+    path = base_dir / pkg_name
+    found = {item.name for item in path.iterdir()}
+    assert filenames == found
+
+
 @pytest.mark.parametrize(
     ["code_dir", "test_dir", "include_tests", "error"],
     [
@@ -196,7 +231,12 @@ def test_cli_generate_location_errors(code_dir, test_dir, include_tests, error):
     ):
         with pytest.raises(typer.Exit) as context:
             generate_cli(
-                layout_file, oas_file, pkg_name, code_dir=code_dir, test_dir=test_dir, include_tests=include_tests
+                oas_file,
+                pkg_name,
+                layout_file=layout_file,
+                code_dir=code_dir,
+                test_dir=test_dir,
+                include_tests=include_tests,
             )
         ex = context.value
         assert ex.exit_code == 1
@@ -219,7 +259,7 @@ Commands with missing operations:
         mock.patch('sys.stdout', new_callable=StringIo) as mock_stdout,
     ):
         with pytest.raises(typer.Exit) as context:
-            generate_cli(layout_file, oas_file, pkg_name, directory.name)
+            generate_cli(oas_file, pkg_name, layout_file, directory.name)
         ex = context.value
         assert ex.exit_code == 1
         assert message == mock_stdout.getvalue()


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

**WARNING:** this is a breaking change for `cli-gen generate`.

Make CLI generation easier because users no longer need to create/generate a layout file!! 

Turn the layout file into an optional argument for `cli-gen generate` (specified with `--layout-file`). When it is not specified, the layout is generated.

## CHANGES
<!-- Please explain at a high-level the changes. -->

Make the `cli-gen generate` layout file a `typer.Option("--layout-file",...)` so users can get a CLI without creating/generating their own layout file.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->