### PR TITLE
Allow ruff to fix whitespace issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ select = [
     "N",  # PEP8 naming conventions
 ]
 fixable = [
-    "D", "E", "I",
+    "D", "E", "I", "W",
 ]
 ignore = [
     "PLR1711",  # "useless" returns make the code more readable


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

This allows the `make delint` to fix the whitespace issues (e.g. trailing space, blank lines containing space).

## CHANGES
<!-- Please explain at a high-level the changes. -->

Add the whitespace category identifier (e.g. `"W"`) to the list of things `ruff` should fix. 

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->