### PR TITLE
Add hooks for suggesting pagination

### DIFF
--- a/openapi_spec_tools/layout/layout_generator.py
+++ b/openapi_spec_tools/layout/layout_generator.py
@@ -1,9 +1,12 @@
 """Declares the LayoutGenerator for inferring a layout from an OpenAPI specification."""
 from typing import Any
+from typing import Optional
 
 from openapi_spec_tools.base_gen.utils import to_snake_case
 from openapi_spec_tools.layout.types import LayoutField
 from openapi_spec_tools.layout.types import LayoutNode
+from openapi_spec_tools.layout.types import PaginationField
+from openapi_spec_tools.layout.types import PaginationNames
 from openapi_spec_tools.layout.utils import DEFAULT_START
 from openapi_spec_tools.types import OasField
 
@@ -101,6 +104,13 @@ class LayoutGenerator:
         current.children.append(path_node)
         return path_node
 
+    def get_pagination(self, op_data: dict[str, Any]) -> Optional[PaginationNames]:
+        """Determine pagination parameters from the operation data.
+
+        Intended to be overridden if you want your suggested layout to contain pagination parameters.
+        """
+        return None
+
     def generate(self, oas: dict[str, Any], prefix: str) -> LayoutNode:
         """Create a suggested layout for the provided OpenAPI spec."""
         main = LayoutNode(DEFAULT_START, DEFAULT_START, description="CLI to manage your application")
@@ -117,13 +127,32 @@ class LayoutGenerator:
                 path_node = self.get_or_create_node_with_parents(main, commands)
                 op_id = op_data.get(OasField.OP_ID)
                 command = self.suggest_command(method, op_id)
+                pagination = self.get_pagination(op_data)
                 path_node.children.append(
-                    LayoutNode(command=command, identifier=op_id)
+                    LayoutNode(command=command, identifier=op_id, pagination=pagination)
                 )
                 # sort the children to match layout linting
                 path_node.children = sorted(path_node.children, key=lambda x: x.command)
 
         return main
+
+
+def pagination_text(pagination: PaginationNames, indent: str) -> str:
+    """Create text for the provided pagination parameters and indent."""
+    text = ""
+    if pagination.items_property:
+        text += f"{indent}{PaginationField.ITEM_PROP.value}: {pagination.items_property}\n"
+    if pagination.item_start:
+        text += f"{indent}{PaginationField.ITEM_START.value}: {pagination.item_start}\n"
+    if pagination.page_start:
+        text += f"{indent}{PaginationField.PAGE_START.value}: {pagination.page_start}\n"
+    if pagination.page_size:
+        text += f"{indent}{PaginationField.PAGE_SIZE.value}: {pagination.page_size}\n"
+    if pagination.next_header:
+        text += f"{indent}{PaginationField.NEXT_HEADER.value}: {pagination.next_header}\n"
+    if pagination.next_property:
+        text += f"{indent}{PaginationField.NEXT_PROP.value}: {pagination.next_property}\n"
+    return text
 
 
 def layout_node_text(node: LayoutNode) -> str:
@@ -137,6 +166,9 @@ def layout_node_text(node: LayoutNode) -> str:
         text += f"{indent}- {LayoutField.NAME.value}: {child.command}\n"
         flavor = LayoutField.OP_ID.value if not child.children else LayoutField.SUB_ID.value
         text += f"{indent}  {flavor}: {child.identifier}\n"
+        if child.pagination:
+            text += f"{indent}  pagination:\n"
+            text += pagination_text(child.pagination, indent * 2)
     text += "\n"
 
     # recursively generate sections for sub-commands

--- a/tests/layout/test_layout_generator.py
+++ b/tests/layout/test_layout_generator.py
@@ -4,7 +4,11 @@ from tempfile import TemporaryDirectory
 import pytest
 
 from openapi_spec_tools.layout.layout_generator import LayoutGenerator
+from openapi_spec_tools.layout.layout_generator import layout_node_text
+from openapi_spec_tools.layout.layout_generator import pagination_text
 from openapi_spec_tools.layout.layout_generator import write_layout
+from openapi_spec_tools.layout.types import LayoutNode
+from openapi_spec_tools.layout.types import PaginationNames
 from openapi_spec_tools.utils import open_oas
 from tests.helpers import asset_filename
 
@@ -69,6 +73,83 @@ def test_suggest_command(method, op_id, expected):
     uut = LayoutGenerator()
     assert expected == uut.suggest_command(method, op_id)
 
+
+ALL_PAGE_TEXT = """\
+itemProperty: itemProp
+itemStart: item
+pageStart: page
+pageSize: size
+nextHeader: My-header
+nextProperty: nextProp
+"""
+ITEMS_PAGE_TEXT = """\
+  itemProperty: itemProp
+  itemStart: item
+"""
+PAGE_PAGE_TEXT = """\
+****pageStart: page
+****pageSize: size
+"""
+
+@pytest.mark.parametrize(
+    ["pagination", "indent", "expected"],
+    [
+        pytest.param(
+            PaginationNames(
+                page_size="size",
+                page_start="page",
+                item_start="item",
+                items_property="itemProp",
+                next_property="nextProp",
+                next_header="My-header",
+            ),
+            "",
+            ALL_PAGE_TEXT,
+            id="all",
+        ),
+        pytest.param(
+            PaginationNames(item_start="item", items_property="itemProp"),
+            "  ",
+            ITEMS_PAGE_TEXT,
+            id="items",
+        ),
+        pytest.param(
+            PaginationNames(page_size="size", page_start="page"),
+            "****",
+            PAGE_PAGE_TEXT,
+            id="page",
+        ),
+    ]
+)
+def test_pagination_text(pagination, indent, expected):
+    actual = pagination_text(pagination, indent)
+    assert expected == actual
+
+
+def test_layout_node_text():
+    node = LayoutNode(
+        command="parent",
+        identifier="this_is_it",
+        description="summary",
+        children=[
+            LayoutNode(command="child1", identifier="my_child", pagination=PaginationNames(page_size="page")),
+            LayoutNode(command="child2", identifier="another_op")
+        ]
+    )
+    text = layout_node_text(node)
+    assert text == """\
+this_is_it:
+    description: summary
+    operations:
+    - name: child1
+      operationId: my_child
+      pagination:
+        pageSize: page
+    - name: child2
+      operationId: another_op
+
+"""
+    
 
 def test_generate_pets():
     oas = open_oas(asset_filename("pet.yaml"))


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Provides hooks to suggest pagination in layout generation.

## CHANGES
<!-- Please explain at a high-level the changes. -->

Added `LayoutGenerator.get_pagination()` to allow for overriding and providing `PaginationNames`.
Updated `layout_node_text()` to add pagination parameters.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->