### PR TITLE
Move a few layout items from the generator to utils module

### DIFF
--- a/openapi_spec_tools/cli/layout.py
+++ b/openapi_spec_tools/cli/layout.py
@@ -21,7 +21,6 @@ from openapi_spec_tools.cli._utils import layout_tree_with_error_handling
 from openapi_spec_tools.cli._utils import open_layout_with_error_handling
 from openapi_spec_tools.cli._utils import open_oas_with_error_handling
 from openapi_spec_tools.layout.layout_generator import LayoutGenerator
-from openapi_spec_tools.layout.layout_generator import write_layout
 from openapi_spec_tools.layout.types import LayoutNode
 from openapi_spec_tools.layout.utils import DEFAULT_START
 from openapi_spec_tools.layout.utils import check_pagination_definitions
@@ -30,6 +29,7 @@ from openapi_spec_tools.layout.utils import operation_order
 from openapi_spec_tools.layout.utils import subcommand_missing_properties
 from openapi_spec_tools.layout.utils import subcommand_order
 from openapi_spec_tools.layout.utils import subcommand_references
+from openapi_spec_tools.layout.utils import write_layout
 
 SEP = "\n    "
 LOG_CLASS = "layout"

--- a/openapi_spec_tools/layout/layout_generator.py
+++ b/openapi_spec_tools/layout/layout_generator.py
@@ -3,9 +3,7 @@ from typing import Any
 from typing import Optional
 
 from openapi_spec_tools.base_gen.utils import to_snake_case
-from openapi_spec_tools.layout.types import LayoutField
 from openapi_spec_tools.layout.types import LayoutNode
-from openapi_spec_tools.layout.types import PaginationField
 from openapi_spec_tools.layout.types import PaginationNames
 from openapi_spec_tools.layout.utils import DEFAULT_START
 from openapi_spec_tools.types import OasField
@@ -135,52 +133,3 @@ class LayoutGenerator:
                 path_node.children = sorted(path_node.children, key=lambda x: x.command)
 
         return main
-
-
-def pagination_text(pagination: PaginationNames, indent: str) -> str:
-    """Create text for the provided pagination parameters and indent."""
-    text = ""
-    if pagination.items_property:
-        text += f"{indent}{PaginationField.ITEM_PROP.value}: {pagination.items_property}\n"
-    if pagination.item_start:
-        text += f"{indent}{PaginationField.ITEM_START.value}: {pagination.item_start}\n"
-    if pagination.page_start:
-        text += f"{indent}{PaginationField.PAGE_START.value}: {pagination.page_start}\n"
-    if pagination.page_size:
-        text += f"{indent}{PaginationField.PAGE_SIZE.value}: {pagination.page_size}\n"
-    if pagination.next_header:
-        text += f"{indent}{PaginationField.NEXT_HEADER.value}: {pagination.next_header}\n"
-    if pagination.next_property:
-        text += f"{indent}{PaginationField.NEXT_PROP.value}: {pagination.next_property}\n"
-    return text
-
-
-def layout_node_text(node: LayoutNode) -> str:
-    """Create text for node, and all children."""
-    indent = "    "
-    text = f"{node.identifier}:\n"
-    text += f"{indent}{LayoutField.DESCRIPTION.value}: {node.description}\n"
-    text += f"{indent}{LayoutField.OPERATIONS.value}:\n"
-
-    for child in node.children:
-        text += f"{indent}- {LayoutField.NAME.value}: {child.command}\n"
-        flavor = LayoutField.OP_ID.value if not child.children else LayoutField.SUB_ID.value
-        text += f"{indent}  {flavor}: {child.identifier}\n"
-        if child.pagination:
-            text += f"{indent}  pagination:\n"
-            text += pagination_text(child.pagination, indent * 2)
-    text += "\n"
-
-    # recursively generate sections for sub-commands
-    sorted_subcommands = sorted(node.subcommands(), key=lambda x: x.identifier)
-    for child in sorted_subcommands:
-        text += layout_node_text(child)
-
-    return text
-
-
-def write_layout(filename: str, node: LayoutNode):
-    """Write the text from the node to the specified file."""
-    with open(filename, "w", encoding="utf-8", newline="\n") as fp:
-        fp.write(layout_node_text(node))
-

--- a/openapi_spec_tools/layout/utils.py
+++ b/openapi_spec_tools/layout/utils.py
@@ -254,3 +254,52 @@ def file_to_tree(filename: str, start: str = DEFAULT_START) -> LayoutNode:
     """Open filename and parse to a LayoutNode tree."""
     data = open_layout(filename)
     return parse_to_tree(data, start)
+
+
+def pagination_text(pagination: PaginationNames, indent: str) -> str:
+    """Create text for the provided pagination parameters and indent."""
+    text = ""
+    if pagination.items_property:
+        text += f"{indent}{PaginationField.ITEM_PROP.value}: {pagination.items_property}\n"
+    if pagination.item_start:
+        text += f"{indent}{PaginationField.ITEM_START.value}: {pagination.item_start}\n"
+    if pagination.page_start:
+        text += f"{indent}{PaginationField.PAGE_START.value}: {pagination.page_start}\n"
+    if pagination.page_size:
+        text += f"{indent}{PaginationField.PAGE_SIZE.value}: {pagination.page_size}\n"
+    if pagination.next_header:
+        text += f"{indent}{PaginationField.NEXT_HEADER.value}: {pagination.next_header}\n"
+    if pagination.next_property:
+        text += f"{indent}{PaginationField.NEXT_PROP.value}: {pagination.next_property}\n"
+    return text
+
+
+def layout_node_text(node: LayoutNode) -> str:
+    """Create text for node, and all children."""
+    indent = "    "
+    text = f"{node.identifier}:\n"
+    text += f"{indent}{LayoutField.DESCRIPTION.value}: {node.description}\n"
+    text += f"{indent}{LayoutField.OPERATIONS.value}:\n"
+
+    for child in node.children:
+        text += f"{indent}- {LayoutField.NAME.value}: {child.command}\n"
+        flavor = LayoutField.OP_ID.value if not child.children else LayoutField.SUB_ID.value
+        text += f"{indent}  {flavor}: {child.identifier}\n"
+        if child.pagination:
+            text += f"{indent}  pagination:\n"
+            text += pagination_text(child.pagination, indent * 2)
+    text += "\n"
+
+    # recursively generate sections for sub-commands
+    sorted_subcommands = sorted(node.subcommands(), key=lambda x: x.identifier)
+    for child in sorted_subcommands:
+        text += layout_node_text(child)
+
+    return text
+
+
+def write_layout(filename: str, node: LayoutNode):
+    """Write the text from the node to the specified file."""
+    with open(filename, "w", encoding="utf-8", newline="\n") as fp:
+        fp.write(layout_node_text(node))
+

--- a/tests/layout/test_layout_generator.py
+++ b/tests/layout/test_layout_generator.py
@@ -4,11 +4,7 @@ from tempfile import TemporaryDirectory
 import pytest
 
 from openapi_spec_tools.layout.layout_generator import LayoutGenerator
-from openapi_spec_tools.layout.layout_generator import layout_node_text
-from openapi_spec_tools.layout.layout_generator import pagination_text
-from openapi_spec_tools.layout.layout_generator import write_layout
-from openapi_spec_tools.layout.types import LayoutNode
-from openapi_spec_tools.layout.types import PaginationNames
+from openapi_spec_tools.layout.utils import write_layout
 from openapi_spec_tools.utils import open_oas
 from tests.helpers import asset_filename
 
@@ -72,83 +68,6 @@ def test_commands_to_identifier(commands, expected):
 def test_suggest_command(method, op_id, expected):
     uut = LayoutGenerator()
     assert expected == uut.suggest_command(method, op_id)
-
-
-ALL_PAGE_TEXT = """\
-itemProperty: itemProp
-itemStart: item
-pageStart: page
-pageSize: size
-nextHeader: My-header
-nextProperty: nextProp
-"""
-ITEMS_PAGE_TEXT = """\
-  itemProperty: itemProp
-  itemStart: item
-"""
-PAGE_PAGE_TEXT = """\
-****pageStart: page
-****pageSize: size
-"""
-
-@pytest.mark.parametrize(
-    ["pagination", "indent", "expected"],
-    [
-        pytest.param(
-            PaginationNames(
-                page_size="size",
-                page_start="page",
-                item_start="item",
-                items_property="itemProp",
-                next_property="nextProp",
-                next_header="My-header",
-            ),
-            "",
-            ALL_PAGE_TEXT,
-            id="all",
-        ),
-        pytest.param(
-            PaginationNames(item_start="item", items_property="itemProp"),
-            "  ",
-            ITEMS_PAGE_TEXT,
-            id="items",
-        ),
-        pytest.param(
-            PaginationNames(page_size="size", page_start="page"),
-            "****",
-            PAGE_PAGE_TEXT,
-            id="page",
-        ),
-    ]
-)
-def test_pagination_text(pagination, indent, expected):
-    actual = pagination_text(pagination, indent)
-    assert expected == actual
-
-
-def test_layout_node_text():
-    node = LayoutNode(
-        command="parent",
-        identifier="this_is_it",
-        description="summary",
-        children=[
-            LayoutNode(command="child1", identifier="my_child", pagination=PaginationNames(page_size="page")),
-            LayoutNode(command="child2", identifier="another_op")
-        ]
-    )
-    text = layout_node_text(node)
-    assert text == """\
-this_is_it:
-    description: summary
-    operations:
-    - name: child1
-      operationId: my_child
-      pagination:
-        pageSize: page
-    - name: child2
-      operationId: another_op
-
-"""
 
 
 def test_generate_pets():

--- a/tests/layout/test_layout_utils.py
+++ b/tests/layout/test_layout_utils.py
@@ -6,9 +6,11 @@ from openapi_spec_tools.layout.utils import check_pagination_definitions
 from openapi_spec_tools.layout.utils import data_to_node
 from openapi_spec_tools.layout.utils import field_to_list
 from openapi_spec_tools.layout.utils import file_to_tree
+from openapi_spec_tools.layout.utils import layout_node_text
 from openapi_spec_tools.layout.utils import open_layout
 from openapi_spec_tools.layout.utils import operation_duplicates
 from openapi_spec_tools.layout.utils import operation_order
+from openapi_spec_tools.layout.utils import pagination_text
 from openapi_spec_tools.layout.utils import parse_extras
 from openapi_spec_tools.layout.utils import parse_pagination
 from openapi_spec_tools.layout.utils import parse_to_tree
@@ -525,3 +527,82 @@ def test_file_to_tree() -> None:
     tree = file_to_tree(filename, "owners")
     assert "owners" == tree.command
     assert set() == {p.command for p in tree.subcommands()}
+
+
+ALL_PAGE_TEXT = """\
+itemProperty: itemProp
+itemStart: item
+pageStart: page
+pageSize: size
+nextHeader: My-header
+nextProperty: nextProp
+"""
+ITEMS_PAGE_TEXT = """\
+  itemProperty: itemProp
+  itemStart: item
+"""
+PAGE_PAGE_TEXT = """\
+****pageStart: page
+****pageSize: size
+"""
+
+@pytest.mark.parametrize(
+    ["pagination", "indent", "expected"],
+    [
+        pytest.param(
+            PaginationNames(
+                page_size="size",
+                page_start="page",
+                item_start="item",
+                items_property="itemProp",
+                next_property="nextProp",
+                next_header="My-header",
+            ),
+            "",
+            ALL_PAGE_TEXT,
+            id="all",
+        ),
+        pytest.param(
+            PaginationNames(item_start="item", items_property="itemProp"),
+            "  ",
+            ITEMS_PAGE_TEXT,
+            id="items",
+        ),
+        pytest.param(
+            PaginationNames(page_size="size", page_start="page"),
+            "****",
+            PAGE_PAGE_TEXT,
+            id="page",
+        ),
+    ]
+)
+def test_pagination_text(pagination, indent, expected):
+    actual = pagination_text(pagination, indent)
+    assert expected == actual
+
+
+def test_layout_node_text():
+    node = LayoutNode(
+        command="parent",
+        identifier="this_is_it",
+        description="summary",
+        children=[
+            LayoutNode(command="child1", identifier="my_child", pagination=PaginationNames(page_size="page")),
+            LayoutNode(command="child2", identifier="another_op")
+        ]
+    )
+    text = layout_node_text(node)
+    assert text == """\
+this_is_it:
+    description: summary
+    operations:
+    - name: child1
+      operationId: my_child
+      pagination:
+        pageSize: page
+    - name: child2
+      operationId: another_op
+
+"""
+
+


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Move a few utilities to a more appropriate module. The utilities were needed by the generator, but could be used by anything wanting to write the layout file.

## CHANGES
<!-- Please explain at a high-level the changes. -->

Move `write_layout()`, `layout_node_text()` and `pagination_text()` to `openapi_spec_tools.layout.utils`.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->