### PR TITLE
Example of extending LayoutGenerator to provide pagination parameters

### DIFF
--- a/examples/cloudtruth-gen-cli/Makefile
+++ b/examples/cloudtruth-gen-cli/Makefile
@@ -6,6 +6,7 @@ help: ## This message
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m\033[0m\n"} /^[$$()% a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 LAYOUT_FILE := layout.yaml
+SUGGESTED_FILE := suggested.yaml
 OPENAPI_SPEC := ct.yaml
 PROJECT_DIRECTORY := .
 PACKAGE_NAME := cloudtruth_gen_cli
@@ -31,12 +32,14 @@ all: install gen lint ## Perform a full cycle
 layout-lint:  ## Check the layout file format
 	$(poetry_run) layout check $(LAYOUT_FILE)
 
-gen: layout-lint ## Generate CLI code
+gen: layout-lint suggest ## Generate CLI code
 	$(poetry_run) cli-gen generate $(OPENAPI_SPEC) $(PACKAGE_NAME) --layout-file $(LAYOUT_FILE) --project-dir $(PROJECT_DIRECTORY) --no-tests
 
 missing: ## Print the OAS operations not in the layout
 	$(poetry_run) cli-gen unreferenced $(LAYOUT_FILE) $(OPENAPI_SPEC)
 
+suggest: ## Use the local code to suggest a layout
+	$(poetry_run) ./layout.py $(OPENAPI_SPEC) $(SUGGESTED_FILE) --prefix /api/v1
 
 ###########
 ##@ Linting

--- a/examples/cloudtruth-gen-cli/layout.py
+++ b/examples/cloudtruth-gen-cli/layout.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""CLI and customized LayoutGenerator"""
+from typing import Any
+from typing import Optional
+from typing_extensions import Annotated
+
+import typer
+
+from openapi_spec_tools.types import OasField
+from openapi_spec_tools.cli.arguments import OpenApiFilenameArgument
+from openapi_spec_tools.cli.arguments import PathPrefixOption
+from openapi_spec_tools.cli.arguments import LogLevelOption
+from openapi_spec_tools.cli.utils import init_logging
+from openapi_spec_tools.cli.utils import open_oas_with_error_handling
+from openapi_spec_tools.cli.utils import write_layout_tree
+from openapi_spec_tools.layout.layout_generator import LayoutGenerator
+from openapi_spec_tools.layout.types import PaginationNames
+
+LOG_CLASS = "ct-layout"
+
+#################################################
+# Top-level CLI stuff
+app = typer.Typer(
+    no_args_is_help=True,
+    help="Generate a suggested layout."
+)
+
+#################################################
+# Generator class
+class CloudTruthLayoutGenerator(LayoutGenerator):
+    def find_parameter(self, params: list[dict[str, Any]], name: str) -> Optional[dict[str, Any]]:
+        for p in params:
+            if p.get(OasField.NAME) == name:
+                return p
+        return None
+
+    def get_pagination(self, op_data: dict[str, Any]) -> Optional[PaginationNames]:
+        params = op_data.get(OasField.PARAMS, [])
+        
+        args = {}
+        if self.find_parameter(params, "page_size"):
+            args['page_size'] = "page_size"
+        if self.find_parameter(params, "page"):
+            args['page_start'] = "page"
+
+        # TODO: use body to determine items_property and next_property
+
+        if not args:
+            return None
+
+        return PaginationNames(**args)
+
+
+#################################################
+# CLI function
+@app.command(
+    "suggest",
+    short_help="Suggest layout based on OpenAPI spec"
+)
+def layout_suggest(
+    openapi_file: OpenApiFilenameArgument,
+    output_file: Annotated[str, typer.Argument(metavar="FILENAME", show_default=False, help="File name for output")],
+    prefix: PathPrefixOption = "",
+    log_level: LogLevelOption = "info",
+) -> None:
+    """Create a suggested layout based on the OpenAPI spec paths and operations.
+
+    This is a way to quick-start creating a layout file, but has a few issues:
+
+    * May have duplicate commands that may need to be fixed (detected with `layout check`)
+
+    * May have some small modules (extra layers), such as `deploy list` instead of a desired `deploy`.
+    """
+    logger = init_logging(log_level, LOG_CLASS)
+    oas = open_oas_with_error_handling(openapi_file, logger)
+    generator = CloudTruthLayoutGenerator()
+    node = generator.generate(oas, prefix)
+
+    write_layout_tree(output_file, node, logger)
+    print(f"Wrote {output_file}")
+    return
+
+if __name__ == "__main__":
+    app()

--- a/examples/cloudtruth-gen-cli/suggested.yaml
+++ b/examples/cloudtruth-gen-cli/suggested.yaml
@@ -1,0 +1,935 @@
+main:
+    description: CLI to manage your application
+    operations:
+    - name: api
+      subcommandId: api
+    - name: audit
+      subcommandId: audit
+    - name: backup
+      subcommandId: backup
+    - name: environments
+      subcommandId: environments
+    - name: features
+      subcommandId: features
+    - name: grants
+      subcommandId: grants
+    - name: groups
+      subcommandId: groups
+    - name: import
+      subcommandId: import
+    - name: integrations
+      subcommandId: integrations
+    - name: invitations
+      subcommandId: invitations
+    - name: memberships
+      subcommandId: memberships
+    - name: organizations
+      subcommandId: organizations
+    - name: projects
+      subcommandId: projects
+    - name: serviceaccounts
+      subcommandId: serviceaccounts
+    - name: types
+      subcommandId: types
+    - name: users
+      subcommandId: users
+    - name: utils
+      subcommandId: utils
+
+api:
+    description: Manage api
+    operations:
+    - name: schema
+      subcommandId: api_schema
+
+api_schema:
+    description: Manage api schema
+    operations:
+    - name: show
+      operationId: api_schema_retrieve
+
+audit:
+    description: Manage audit
+    operations:
+    - name: list
+      operationId: audit_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: show
+      operationId: audit_retrieve
+    - name: summary
+      subcommandId: audit_summary
+
+audit_summary:
+    description: Manage audit summary
+    operations:
+    - name: show
+      operationId: audit_summary_retrieve
+
+backup:
+    description: Manage backup
+    operations:
+    - name: snapshot
+      subcommandId: backup_snapshot
+
+backup_snapshot:
+    description: Manage backup snapshot
+    operations:
+    - name: create
+      operationId: backup_snapshot_create
+
+environments:
+    description: Manage environments
+    operations:
+    - name: create
+      operationId: environments_create
+    - name: delete
+      operationId: environments_destroy
+    - name: list
+      operationId: environments_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: pushes
+      subcommandId: environments_pushes
+    - name: set
+      operationId: environments_update
+    - name: show
+      operationId: environments_retrieve
+    - name: tags
+      subcommandId: environments_tags
+    - name: update
+      operationId: environments_partial_update
+    - name: copy
+      subcommandId: environments_copy
+
+environments_copy:
+    description: Manage environments copy
+    operations:
+    - name: create
+      operationId: environments_copy_create
+
+environments_pushes:
+    description: Manage environments pushes
+    operations:
+    - name: list
+      operationId: environments_pushes_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+
+environments_tags:
+    description: Manage environments tags
+    operations:
+    - name: create
+      operationId: environments_tags_create
+    - name: delete
+      operationId: environments_tags_destroy
+    - name: list
+      operationId: environments_tags_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: set
+      operationId: environments_tags_update
+    - name: show
+      operationId: environments_tags_retrieve
+    - name: update
+      operationId: environments_tags_partial_update
+
+features:
+    description: Manage features
+    operations:
+    - name: show
+      operationId: features_retrieve
+
+grants:
+    description: Manage grants
+    operations:
+    - name: create
+      operationId: grants_create
+    - name: delete
+      operationId: grants_destroy
+    - name: list
+      operationId: grants_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: set
+      operationId: grants_update
+    - name: show
+      operationId: grants_retrieve
+    - name: update
+      operationId: grants_partial_update
+    - name: multi
+      subcommandId: grants_multi
+
+grants_multi:
+    description: Manage grants multi
+    operations:
+    - name: delete
+      operationId: grants_multi_destroy
+
+groups:
+    description: Manage groups
+    operations:
+    - name: create
+      operationId: groups_create
+    - name: delete
+      operationId: groups_destroy
+    - name: list
+      operationId: groups_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: set
+      operationId: groups_update
+    - name: show
+      operationId: groups_retrieve
+    - name: update
+      operationId: groups_partial_update
+    - name: add
+      subcommandId: groups_add
+    - name: remove
+      subcommandId: groups_remove
+
+groups_add:
+    description: Manage groups add
+    operations:
+    - name: create
+      operationId: groups_add_create
+
+groups_remove:
+    description: Manage groups remove
+    operations:
+    - name: create
+      operationId: groups_remove_create
+
+import:
+    description: Manage import
+    operations:
+    - name: create
+      operationId: import_create
+
+integrations:
+    description: Manage integrations
+    operations:
+    - name: aws
+      subcommandId: integrations_aws
+    - name: azure
+      subcommandId: integrations_azure
+    - name: explore
+      subcommandId: integrations_explore
+    - name: github
+      subcommandId: integrations_github
+
+integrations_aws:
+    description: Manage integrations aws
+    operations:
+    - name: create
+      operationId: integrations_aws_create
+    - name: delete
+      operationId: integrations_aws_destroy
+    - name: list
+      operationId: integrations_aws_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: pulls
+      subcommandId: integrations_aws_pulls
+    - name: pushes
+      subcommandId: integrations_aws_pushes
+    - name: set
+      operationId: integrations_aws_update
+    - name: show
+      operationId: integrations_aws_retrieve
+    - name: update
+      operationId: integrations_aws_partial_update
+    - name: scan
+      subcommandId: integrations_aws_scan
+
+integrations_aws_pulls:
+    description: Manage integrations aws pulls
+    operations:
+    - name: create
+      operationId: integrations_aws_pulls_create
+    - name: delete
+      operationId: integrations_aws_pulls_destroy
+    - name: list
+      operationId: integrations_aws_pulls_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: set
+      operationId: integrations_aws_pulls_update
+    - name: show
+      operationId: integrations_aws_pulls_retrieve
+    - name: tasks
+      subcommandId: integrations_aws_pulls_tasks
+    - name: update
+      operationId: integrations_aws_pulls_partial_update
+    - name: sync
+      subcommandId: integrations_aws_pulls_sync
+
+integrations_aws_pulls_sync:
+    description: Manage integrations aws pulls sync
+    operations:
+    - name: create
+      operationId: integrations_aws_pulls_sync_create
+
+integrations_aws_pulls_tasks:
+    description: Manage integrations aws pulls tasks
+    operations:
+    - name: list
+      operationId: integrations_aws_pulls_tasks_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: show
+      operationId: integrations_aws_pulls_tasks_retrieve
+    - name: steps
+      subcommandId: integrations_aws_pulls_tasks_steps
+
+integrations_aws_pulls_tasks_steps:
+    description: Manage integrations aws pulls tasks steps
+    operations:
+    - name: list
+      operationId: integrations_aws_pulls_tasks_steps_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: show
+      operationId: integrations_aws_pulls_tasks_steps_retrieve
+
+integrations_aws_pushes:
+    description: Manage integrations aws pushes
+    operations:
+    - name: create
+      operationId: integrations_aws_pushes_create
+    - name: delete
+      operationId: integrations_aws_pushes_destroy
+    - name: list
+      operationId: integrations_aws_pushes_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: set
+      operationId: integrations_aws_pushes_update
+    - name: show
+      operationId: integrations_aws_pushes_retrieve
+    - name: tasks
+      subcommandId: integrations_aws_pushes_tasks
+    - name: update
+      operationId: integrations_aws_pushes_partial_update
+    - name: sync
+      subcommandId: integrations_aws_pushes_sync
+
+integrations_aws_pushes_sync:
+    description: Manage integrations aws pushes sync
+    operations:
+    - name: create
+      operationId: integrations_aws_pushes_sync_create
+
+integrations_aws_pushes_tasks:
+    description: Manage integrations aws pushes tasks
+    operations:
+    - name: list
+      operationId: integrations_aws_pushes_tasks_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: show
+      operationId: integrations_aws_pushes_tasks_retrieve
+    - name: steps
+      subcommandId: integrations_aws_pushes_tasks_steps
+
+integrations_aws_pushes_tasks_steps:
+    description: Manage integrations aws pushes tasks steps
+    operations:
+    - name: list
+      operationId: integrations_aws_pushes_tasks_steps_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: show
+      operationId: integrations_aws_pushes_tasks_steps_retrieve
+
+integrations_aws_scan:
+    description: Manage integrations aws scan
+    operations:
+    - name: create
+      operationId: integrations_aws_scan_create
+
+integrations_azure:
+    description: Manage integrations azure
+    operations:
+    - name: key-vault
+      subcommandId: integrations_azure_key_vault
+
+integrations_azure_key_vault:
+    description: Manage integrations azure key-vault
+    operations:
+    - name: create
+      operationId: integrations_azure_key_vault_create
+    - name: delete
+      operationId: integrations_azure_key_vault_destroy
+    - name: list
+      operationId: integrations_azure_key_vault_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: pulls
+      subcommandId: integrations_azure_key_vault_pulls
+    - name: pushes
+      subcommandId: integrations_azure_key_vault_pushes
+    - name: set
+      operationId: integrations_azure_key_vault_update
+    - name: show
+      operationId: integrations_azure_key_vault_retrieve
+    - name: update
+      operationId: integrations_azure_key_vault_partial_update
+    - name: scan
+      subcommandId: integrations_azure_key_vault_scan
+
+integrations_azure_key_vault_pulls:
+    description: Manage integrations azure key-vault pulls
+    operations:
+    - name: create
+      operationId: integrations_azure_key_vault_pulls_create
+    - name: delete
+      operationId: integrations_azure_key_vault_pulls_destroy
+    - name: list
+      operationId: integrations_azure_key_vault_pulls_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: set
+      operationId: integrations_azure_key_vault_pulls_update
+    - name: show
+      operationId: integrations_azure_key_vault_pulls_retrieve
+    - name: tasks
+      subcommandId: integrations_azure_key_vault_pulls_tasks
+    - name: update
+      operationId: integrations_azure_key_vault_pulls_partial_update
+    - name: sync
+      subcommandId: integrations_azure_key_vault_pulls_sync
+
+integrations_azure_key_vault_pulls_sync:
+    description: Manage integrations azure key-vault pulls sync
+    operations:
+    - name: create
+      operationId: integrations_azure_key_vault_pulls_sync_create
+
+integrations_azure_key_vault_pulls_tasks:
+    description: Manage integrations azure key-vault pulls tasks
+    operations:
+    - name: list
+      operationId: integrations_azure_key_vault_pulls_tasks_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: show
+      operationId: integrations_azure_key_vault_pulls_tasks_retrieve
+    - name: steps
+      subcommandId: integrations_azure_key_vault_pulls_tasks_steps
+
+integrations_azure_key_vault_pulls_tasks_steps:
+    description: Manage integrations azure key-vault pulls tasks steps
+    operations:
+    - name: list
+      operationId: integrations_azure_key_vault_pulls_tasks_steps_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: show
+      operationId: integrations_azure_key_vault_pulls_tasks_steps_retrieve
+
+integrations_azure_key_vault_pushes:
+    description: Manage integrations azure key-vault pushes
+    operations:
+    - name: create
+      operationId: integrations_azure_key_vault_pushes_create
+    - name: delete
+      operationId: integrations_azure_key_vault_pushes_destroy
+    - name: list
+      operationId: integrations_azure_key_vault_pushes_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: set
+      operationId: integrations_azure_key_vault_pushes_update
+    - name: show
+      operationId: integrations_azure_key_vault_pushes_retrieve
+    - name: tasks
+      subcommandId: integrations_azure_key_vault_pushes_tasks
+    - name: update
+      operationId: integrations_azure_key_vault_pushes_partial_update
+    - name: sync
+      subcommandId: integrations_azure_key_vault_pushes_sync
+
+integrations_azure_key_vault_pushes_sync:
+    description: Manage integrations azure key-vault pushes sync
+    operations:
+    - name: create
+      operationId: integrations_azure_key_vault_pushes_sync_create
+
+integrations_azure_key_vault_pushes_tasks:
+    description: Manage integrations azure key-vault pushes tasks
+    operations:
+    - name: list
+      operationId: integrations_azure_key_vault_pushes_tasks_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: show
+      operationId: integrations_azure_key_vault_pushes_tasks_retrieve
+    - name: steps
+      subcommandId: integrations_azure_key_vault_pushes_tasks_steps
+
+integrations_azure_key_vault_pushes_tasks_steps:
+    description: Manage integrations azure key-vault pushes tasks steps
+    operations:
+    - name: list
+      operationId: integrations_azure_key_vault_pushes_tasks_steps_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: show
+      operationId: integrations_azure_key_vault_pushes_tasks_steps_retrieve
+
+integrations_azure_key_vault_scan:
+    description: Manage integrations azure key-vault scan
+    operations:
+    - name: create
+      operationId: integrations_azure_key_vault_scan_create
+
+integrations_explore:
+    description: Manage integrations explore
+    operations:
+    - name: list
+      operationId: integrations_explore_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+
+integrations_github:
+    description: Manage integrations github
+    operations:
+    - name: create
+      operationId: integrations_github_create
+    - name: delete
+      operationId: integrations_github_destroy
+    - name: list
+      operationId: integrations_github_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: pulls
+      subcommandId: integrations_github_pulls
+    - name: show
+      operationId: integrations_github_retrieve
+
+integrations_github_pulls:
+    description: Manage integrations github pulls
+    operations:
+    - name: list
+      operationId: integrations_github_pulls_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: set
+      operationId: integrations_github_pulls_update
+    - name: show
+      operationId: integrations_github_pulls_retrieve
+    - name: tasks
+      subcommandId: integrations_github_pulls_tasks
+    - name: update
+      operationId: integrations_github_pulls_partial_update
+    - name: sync
+      subcommandId: integrations_github_pulls_sync
+
+integrations_github_pulls_sync:
+    description: Manage integrations github pulls sync
+    operations:
+    - name: create
+      operationId: integrations_github_pulls_sync_create
+
+integrations_github_pulls_tasks:
+    description: Manage integrations github pulls tasks
+    operations:
+    - name: list
+      operationId: integrations_github_pulls_tasks_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: show
+      operationId: integrations_github_pulls_tasks_retrieve
+    - name: steps
+      subcommandId: integrations_github_pulls_tasks_steps
+
+integrations_github_pulls_tasks_steps:
+    description: Manage integrations github pulls tasks steps
+    operations:
+    - name: list
+      operationId: integrations_github_pulls_tasks_steps_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: show
+      operationId: integrations_github_pulls_tasks_steps_retrieve
+
+invitations:
+    description: Manage invitations
+    operations:
+    - name: create
+      operationId: invitations_create
+    - name: delete
+      operationId: invitations_destroy
+    - name: list
+      operationId: invitations_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: set
+      operationId: invitations_update
+    - name: show
+      operationId: invitations_retrieve
+    - name: update
+      operationId: invitations_partial_update
+    - name: accept
+      subcommandId: invitations_accept
+    - name: resend
+      subcommandId: invitations_resend
+
+invitations_accept:
+    description: Manage invitations accept
+    operations:
+    - name: create
+      operationId: invitations_accept_create
+
+invitations_resend:
+    description: Manage invitations resend
+    operations:
+    - name: create
+      operationId: invitations_resend_create
+
+memberships:
+    description: Manage memberships
+    operations:
+    - name: create
+      operationId: memberships_create
+    - name: delete
+      operationId: memberships_destroy
+    - name: list
+      operationId: memberships_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: set
+      operationId: memberships_update
+    - name: show
+      operationId: memberships_retrieve
+    - name: update
+      operationId: memberships_partial_update
+
+organizations:
+    description: Manage organizations
+    operations:
+    - name: create
+      operationId: organizations_create
+    - name: delete
+      operationId: organizations_destroy
+    - name: list
+      operationId: organizations_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: set
+      operationId: organizations_update
+    - name: show
+      operationId: organizations_retrieve
+    - name: update
+      operationId: organizations_partial_update
+
+projects:
+    description: Manage projects
+    operations:
+    - name: create
+      operationId: projects_create
+    - name: delete
+      operationId: projects_destroy
+    - name: list
+      operationId: projects_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: set
+      operationId: projects_update
+    - name: show
+      operationId: projects_retrieve
+    - name: update
+      operationId: projects_partial_update
+    - name: copy
+      subcommandId: projects_copy
+    - name: parameter-export
+      subcommandId: projects_parameter_export
+    - name: parameters
+      subcommandId: projects_parameters
+    - name: template-preview
+      subcommandId: projects_template_preview
+    - name: templates
+      subcommandId: projects_templates
+
+projects_copy:
+    description: Manage projects copy
+    operations:
+    - name: create
+      operationId: projects_copy_create
+
+projects_parameter_export:
+    description: Manage projects parameter-export
+    operations:
+    - name: list
+      operationId: projects_parameter_export_list
+
+projects_parameters:
+    description: Manage projects parameters
+    operations:
+    - name: create
+      operationId: projects_parameters_create
+    - name: delete
+      operationId: projects_parameters_destroy
+    - name: list
+      operationId: projects_parameters_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: pushes
+      subcommandId: projects_parameters_pushes
+    - name: rules
+      subcommandId: projects_parameters_rules
+    - name: set
+      operationId: projects_parameters_update
+    - name: show
+      operationId: projects_parameters_retrieve
+    - name: update
+      operationId: projects_parameters_partial_update
+    - name: values
+      subcommandId: projects_parameters_values
+    - name: copy
+      subcommandId: projects_parameters_copy
+    - name: timeline
+      subcommandId: projects_parameters_timeline
+    - name: duality
+      subcommandId: projects_parameters_duality
+    - name: timelines
+      subcommandId: projects_parameters_timelines
+
+projects_parameters_copy:
+    description: Manage projects parameters copy
+    operations:
+    - name: create
+      operationId: projects_parameters_copy_create
+
+projects_parameters_duality:
+    description: Manage projects parameters duality
+    operations:
+    - name: list
+      operationId: projects_parameters_duality_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+
+projects_parameters_pushes:
+    description: Manage projects parameters pushes
+    operations:
+    - name: list
+      operationId: projects_parameters_pushes_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+
+projects_parameters_rules:
+    description: Manage projects parameters rules
+    operations:
+    - name: create
+      operationId: projects_parameters_rules_create
+    - name: delete
+      operationId: projects_parameters_rules_destroy
+    - name: list
+      operationId: projects_parameters_rules_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: set
+      operationId: projects_parameters_rules_update
+    - name: show
+      operationId: projects_parameters_rules_retrieve
+    - name: update
+      operationId: projects_parameters_rules_partial_update
+
+projects_parameters_timeline:
+    description: Manage projects parameters timeline
+    operations:
+    - name: show
+      operationId: projects_parameters_timeline_retrieve
+
+projects_parameters_timelines:
+    description: Manage projects parameters timelines
+    operations:
+    - name: show
+      operationId: projects_parameters_timelines_retrieve
+
+projects_parameters_values:
+    description: Manage projects parameters values
+    operations:
+    - name: create
+      operationId: projects_parameters_values_create
+    - name: delete
+      operationId: projects_parameters_values_destroy
+    - name: list
+      operationId: projects_parameters_values_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: set
+      operationId: projects_parameters_values_update
+    - name: show
+      operationId: projects_parameters_values_retrieve
+    - name: update
+      operationId: projects_parameters_values_partial_update
+
+projects_template_preview:
+    description: Manage projects template-preview
+    operations:
+    - name: create
+      operationId: projects_template_preview_create
+
+projects_templates:
+    description: Manage projects templates
+    operations:
+    - name: create
+      operationId: projects_templates_create
+    - name: delete
+      operationId: projects_templates_destroy
+    - name: list
+      operationId: projects_templates_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: set
+      operationId: projects_templates_update
+    - name: show
+      operationId: projects_templates_retrieve
+    - name: update
+      operationId: projects_templates_partial_update
+    - name: timeline
+      subcommandId: projects_templates_timeline
+    - name: timelines
+      subcommandId: projects_templates_timelines
+
+projects_templates_timeline:
+    description: Manage projects templates timeline
+    operations:
+    - name: show
+      operationId: projects_templates_timeline_retrieve
+
+projects_templates_timelines:
+    description: Manage projects templates timelines
+    operations:
+    - name: show
+      operationId: projects_templates_timelines_retrieve
+
+serviceaccounts:
+    description: Manage serviceaccounts
+    operations:
+    - name: create
+      operationId: serviceaccounts_create
+    - name: delete
+      operationId: serviceaccounts_destroy
+    - name: list
+      operationId: serviceaccounts_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: set
+      operationId: serviceaccounts_update
+    - name: show
+      operationId: serviceaccounts_retrieve
+    - name: update
+      operationId: serviceaccounts_partial_update
+
+types:
+    description: Manage types
+    operations:
+    - name: create
+      operationId: types_create
+    - name: delete
+      operationId: types_destroy
+    - name: list
+      operationId: types_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: rules
+      subcommandId: types_rules
+    - name: set
+      operationId: types_update
+    - name: show
+      operationId: types_retrieve
+    - name: update
+      operationId: types_partial_update
+
+types_rules:
+    description: Manage types rules
+    operations:
+    - name: create
+      operationId: types_rules_create
+    - name: delete
+      operationId: types_rules_destroy
+    - name: list
+      operationId: types_rules_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: set
+      operationId: types_rules_update
+    - name: show
+      operationId: types_rules_retrieve
+    - name: update
+      operationId: types_rules_partial_update
+
+users:
+    description: Manage users
+    operations:
+    - name: delete
+      operationId: users_destroy
+    - name: list
+      operationId: users_list
+      pagination:
+        pageStart: page
+        pageSize: page_size
+    - name: show
+      operationId: users_retrieve
+    - name: current
+      subcommandId: users_current
+
+users_current:
+    description: Manage users current
+    operations:
+    - name: show
+      operationId: users_current_retrieve
+
+utils:
+    description: Manage utils
+    operations:
+    - name: generate-password
+      subcommandId: utils_generate_password
+
+utils_generate_password:
+    description: Manage utils generate-password
+    operations:
+    - name: create
+      operationId: utils_generate_password_create
+

--- a/openapi_spec_tools/cli/layout.py
+++ b/openapi_spec_tools/cli/layout.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 """Implement the 'layout' CLI."""
-from datetime import datetime
 from enum import Enum
 from typing import Annotated
 
@@ -20,6 +19,7 @@ from openapi_spec_tools.cli.utils import init_logging
 from openapi_spec_tools.cli.utils import layout_tree_with_error_handling
 from openapi_spec_tools.cli.utils import open_layout_with_error_handling
 from openapi_spec_tools.cli.utils import open_oas_with_error_handling
+from openapi_spec_tools.cli.utils import write_layout_tree
 from openapi_spec_tools.layout.layout_generator import LayoutGenerator
 from openapi_spec_tools.layout.types import LayoutNode
 from openapi_spec_tools.layout.utils import DEFAULT_START
@@ -29,7 +29,6 @@ from openapi_spec_tools.layout.utils import operation_order
 from openapi_spec_tools.layout.utils import subcommand_missing_properties
 from openapi_spec_tools.layout.utils import subcommand_order
 from openapi_spec_tools.layout.utils import subcommand_references
-from openapi_spec_tools.layout.utils import write_layout
 
 SEP = "\n    "
 LOG_CLASS = "layout"
@@ -211,10 +210,7 @@ def layout_suggest(
     generator = LayoutGenerator()
     node = generator.generate(oas, prefix)
 
-    start = datetime.now()
-    write_layout(output_file, node)
-    delta = datetime.now() - start
-    logger.info(f"Writing {output_file} took {delta.total_seconds()} seconds")
+    write_layout_tree(output_file, node, logger)
     print(f"Wrote {output_file}")
     return
 

--- a/openapi_spec_tools/cli/utils.py
+++ b/openapi_spec_tools/cli/utils.py
@@ -12,6 +12,7 @@ from rich.console import Console
 from openapi_spec_tools.layout.types import LayoutNode
 from openapi_spec_tools.layout.utils import file_to_tree
 from openapi_spec_tools.layout.utils import open_layout
+from openapi_spec_tools.layout.utils import write_layout
 from openapi_spec_tools.utils import open_oas
 
 # Common argument definition
@@ -112,6 +113,14 @@ def layout_tree_with_error_handling(filename: str, start: str, logger: logging.L
 
     typer.echo(f"ERROR: {message}")
     raise typer.Exit(1)
+
+
+def write_layout_tree(filename: str, node: LayoutNode, logger: logging.Logger) -> None:
+    """Write the layout node tree to the specified file."""
+    start = datetime.now()
+    write_layout(filename, node)
+    delta = datetime.now() - start
+    logger.info(f"Writing {filename} took {delta.total_seconds()} seconds")
 
 
 def console_factory() -> Console:


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

The pagination parameters are specific to an implementation. The `CloudTruthLayoutGenerator` considers the typical pagination parameters it uses, and suggests these for the operations where the standard page parameters are set.

## CHANGES
<!-- Please explain at a high-level the changes. -->

1. Add `openapi_spec_tools.cli.utils` function for writing the layout file with logging.
2. In `examples/cloudtruth-gen-cli/`, add a `layout.py` that overrides the `LayoutGenerator.get_pagination()` and provides useful data.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->