### PR TITLE
Add property level option to API generation

### DIFF
--- a/openapi_spec_tools/api_gen/property_generator.py
+++ b/openapi_spec_tools/api_gen/property_generator.py
@@ -1,0 +1,233 @@
+"""Declares the PropertyApiGenerator class."""
+from copy import deepcopy
+from typing import Any
+
+from openapi_spec_tools.api_gen.api_generator import ApiGenerator
+from openapi_spec_tools.base_gen.constants import COLLECTIONS
+from openapi_spec_tools.base_gen.constants import NL
+from openapi_spec_tools.base_gen.constants import SEP1
+from openapi_spec_tools.base_gen.utils import maybe_quoted
+from openapi_spec_tools.base_gen.utils import quoted
+from openapi_spec_tools.base_gen.utils import shallow
+from openapi_spec_tools.layout.types import LayoutNode
+from openapi_spec_tools.types import OasField
+
+
+class PropertyApiGenerator(ApiGenerator):
+    """Generates an API with body expanded to the first level of properties."""
+
+    def op_body_top_properties(self, operation: dict[str, Any]) -> dict[str, Any]:
+        """Get a list of top-level properties for the operation."""
+        name, schema = self.op_body_schema(operation)
+        if not schema:
+            return {}
+
+        return self.model_properties(name, schema)
+
+    def model_properties(self, name: str, schema: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0912
+        """Get a list of settable model properties."""
+        model = deepcopy(schema)
+        body_props = {}
+
+        # start with the base-classes in allOf
+        for parent in model.get(OasField.ALL_OF, []):
+            reference = parent.get(OasField.REFS, "")
+            if reference:
+                sub_model = self.get_model(reference)
+            else:
+                sub_model = deepcopy(parent)
+            required_sub = sub_model.get(OasField.REQUIRED, [])
+            for sub_name, sub_data in sub_model.get(OasField.PROPS, {}).items():
+                if sub_data.get(OasField.READ_ONLY):
+                    continue
+
+                sub_data[OasField.REQUIRED.value] = sub_data.get(OasField.REQUIRED) or sub_name in required_sub
+                ref = sub_data.get(OasField.REFS)
+                if ref:
+                    sub_data[OasField.X_REF.value] = self.short_reference_name(ref)
+                body_props[sub_name] = sub_data
+
+        any_of = model.pop(OasField.ANY_OF, None)
+        if any_of:
+            if len(any_of) != 1:
+                self.logger.info(f"Grabbing anyOf[0] item from {name}")
+                self.logger.debug(f"{name} anyOf selected: {shallow(any_of[0])}")
+            # just grab the first one... not sure this is the best choice, but need to do something
+            model.update(any_of[0])
+
+        one_of = model.pop(OasField.ONE_OF, None)
+        if one_of:
+            updated = self.condense_one_of(one_of)
+            if len(updated) != 1:
+                self.logger.info(f"Grabbing oneOf[0] item from {name}")
+                self.logger.debug(f"{name} oneOf selected: {shallow(updated[0])}")
+            # just grab the first one... not sure this is the best choice, but need to do something
+            model.update(updated[0])
+
+        reference = model.get(OasField.REFS, "")
+        short_refname = self.short_reference_name(reference)
+        if reference:
+            model.update(self.get_model(reference))
+            model[OasField.X_REF.value] = short_refname
+        required_props = model.get(OasField.REQUIRED, [])
+
+        # copy the individual properties
+        for prop_name, prop_data in model.get(OasField.PROPS, {}).items():
+            if prop_data.get(OasField.READ_ONLY, False):
+                continue
+
+            prop_data[OasField.REQUIRED.value] = prop_name in required_props
+
+            collection_type = self.model_collection_type(prop_data)
+            if collection_type:
+                item_model = prop_data.pop(OasField.ITEMS, {})
+                prop_data[OasField.X_COLLECT.value] = COLLECTIONS.get(collection_type)
+                prop_data.update(item_model)
+
+            prop_ref = prop_data.get(OasField.REFS, "")
+            sub_model = self.get_model(prop_ref)
+            if sub_model:
+                prop_data.update(sub_model)
+            prop_short_ref = self.short_reference_name(prop_ref)
+            if prop_short_ref:
+                prop_data[OasField.X_REF.value] = prop_short_ref
+
+            body_props[prop_name] = prop_data
+
+        return body_props
+
+
+    def op_body_arguments(self, properties: dict[str, Any]) -> list[str]:
+        """Convert the body parameter dictionary into a list of API function arguments/help."""
+        args = []
+        for prop_name, prop_data in properties.items():
+            help = self.op_short_help(prop_data)
+            short_ref = prop_data.get(OasField.X_REF)
+            required = prop_data.get(OasField.REQUIRED)
+            default = prop_data.get(OasField.DEFAULT)
+            collection = prop_data.get(OasField.X_COLLECT)
+            py_type = self.schema_to_pytype(prop_data)
+            choices = prop_data.get(OasField.ENUM)
+            if prop_data.get(OasField.PROPS):
+                py_type = "dict[str, Any]"
+            if not py_type:
+                py_type = "Any"
+            else:
+                if py_type == "str" and default is not None:
+                    default = str(default)
+                if collection:
+                    py_type = f"{collection}[{py_type}]"
+                if not required:
+                    py_type = f"Optional[{py_type}]"
+            if help:
+                pass
+            elif short_ref:
+                help = f"see {short_ref} for info"
+            elif choices:
+                help = f"choices: {', '.join([str(_) for _ in choices])}"
+            if required and "required" not in help.lower():
+                help += " [required]"
+            full_help = "" if not help else f"  # {help}"
+
+            # need to provide a default, since it may come AFTER option parameters with defaults
+            args.append(f"{self.variable_name(prop_name)}: {py_type} = {maybe_quoted(default)},{full_help}")
+
+        return args
+
+
+    def op_body_formation(self, properties: dict[str, Any]) -> str:
+        """Create body parameter and poulates it when there are body paramters."""
+        if not properties:
+            return ""
+
+        lines = ["body = {}"]
+        for prop_name, prop_data in properties.items():
+            var_name = self.variable_name(prop_name)
+            deprecated = prop_data.get(OasField.DEPRECATED, False)
+            x_deprecated = prop_data.get(OasField.X_DEPRECATED, None)
+            dep_msg = ""
+            if x_deprecated:
+                dep_msg = f"{var_name} was deprecated in {x_deprecated} and should not be used"
+            elif deprecated:
+                dep_msg = f"{var_name} is deprecated and should not be used"
+
+            if prop_data.get(OasField.REQUIRED):
+                lines.append(f'body["{prop_name}"] = {var_name}')
+            else:
+                lines.append(f'if {var_name} is not None:')
+                if dep_msg:
+                    lines.append(f'    _l.logger().warning("{dep_msg}")')
+                lines.append(f'    body["{prop_name}"] = {var_name}')
+
+        return SEP1 + SEP1.join(lines)
+
+    def function_definition(self, node: LayoutNode) -> str:
+        """Generate the function text for the provided LayoutNode."""
+        op = self.operations.get(node.identifier)
+        method = op.get(OasField.X_METHOD).upper()
+        path = op.get(OasField.X_PATH)
+        path_params = self.op_params(op, "path")
+        query_params = self.params_to_settable_properties(self.op_params(op, "query"))
+        header_params = self.params_to_settable_properties(self.op_params(op, "header"))
+        body_params = self.op_body_top_properties(op)
+
+        req_args = []
+        req_args.append(quoted(method))
+        req_args.extend([
+            "url",
+            "headers=headers",
+            "params=params",
+        ])
+        if body_params:
+            req_args.append("body=body")
+        req_args.append("timeout=_api_timeout")
+
+        deprecation_warning = ""
+        deprecated = op.get(OasField.DEPRECATED, False)
+        x_deprecated = op.get(OasField.X_DEPRECATED, None)
+        if x_deprecated:
+            message = f"{node.identifier} was deprecated in {x_deprecated}, and should not be used."
+            deprecation_warning = SEP1 + f'_l.logger().warning("{message}")'
+        elif deprecated:
+            message = f"{node.identifier} is deprecated and should not be used."
+            deprecation_warning = SEP1 + f'_l.logger().warning("{message}")'
+
+        func_name = self.function_name(node.identifier)
+        func_args = []
+        func_args.extend(self.op_path_arguments(path_params))
+        func_args.extend(self.op_query_arguments(query_params))
+        func_args.extend(self.op_query_arguments(header_params))
+        func_args.extend(self.op_body_arguments(body_params))
+        func_args.extend(self.command_infra_arguments(node))
+        args_str = SEP1 + SEP1.join(func_args) + NL
+
+        self.logger.debug(f"{func_name}({len(path_params)} path, {len(query_params)} query")
+
+        user_header_init = ""
+        user_header_arg = ""
+        if header_params:
+            user_header_arg = ", **user_headers"
+            lines = ["user_headers = {}"]
+            for p in header_params:
+                name = p.get(OasField.NAME)
+                var_name = self.variable_name(name)
+                lines.append(f"if {var_name} is not None:")
+                lines.append(f"    user_headers[{quoted(name)}] = {var_name}")
+            user_header_init = NL + SEP1 + SEP1.join(lines) + NL
+
+        return f"""
+{self.enum_definitions(path_params, query_params + header_params, {})}
+def {func_name}({args_str}) -> Any:
+    {self.op_doc_string(op)}# handler for {node.identifier}: {method} {path}
+    {self.init_infra_args(op)}
+
+    _l.init_logging(_log_level){deprecation_warning}{user_header_init}
+    headers = _r.request_headers(_api_key{self.op_content_header(op)}{user_header_arg})
+    url = _r.create_url({self.op_url_params(path)})
+
+    params = {self.op_param_formation(query_params)}{self.op_body_formation(body_params)}
+
+    data = _r.request({', '.join(req_args)})
+    return data
+"""
+

--- a/openapi_spec_tools/cli/api_gen.py
+++ b/openapi_spec_tools/cli/api_gen.py
@@ -11,6 +11,7 @@ from openapi_spec_tools.api_gen.files import copy_api_infrastructure
 from openapi_spec_tools.api_gen.files import generate_api_node
 from openapi_spec_tools.api_gen.flat_generator import FlatApiGenerator
 from openapi_spec_tools.api_gen.opaque_generator import OpaqueApiGenerator
+from openapi_spec_tools.api_gen.property_generator import PropertyApiGenerator
 from openapi_spec_tools.base_gen.files import set_copyright
 from openapi_spec_tools.cli.arguments import CodeDirectoryOption
 from openapi_spec_tools.cli.arguments import CopyrightFileOption
@@ -34,6 +35,7 @@ class BodyType(str, Enum):
     """Different body types for API generated code."""
 
     FLAT = "flat"
+    PROPERTY = "property"
     OPAQUE = "opaque"
 
 
@@ -91,6 +93,8 @@ def generate_api(
 
     if body_type == BodyType.FLAT:
         generator = FlatApiGenerator(package_name, oas, logger)
+    elif body_type == BodyType.PROPERTY:
+        generator = PropertyApiGenerator(package_name, oas, logger)
     else:
         generator = OpaqueApiGenerator(package_name, oas, logger)
     generate_api_node(generator, commands, code_dir)

--- a/tests/api_gen/test_property_generator.py
+++ b/tests/api_gen/test_property_generator.py
@@ -1,0 +1,187 @@
+import pytest
+
+from openapi_spec_tools.api_gen.property_generator import PropertyApiGenerator
+from openapi_spec_tools.layout.types import LayoutNode
+from openapi_spec_tools.types import OasField
+from openapi_spec_tools.utils import map_operations
+from openapi_spec_tools.utils import open_oas
+from tests.api_gen.constants import *  # noqa: F403
+from tests.helpers import asset_filename
+
+
+@pytest.mark.parametrize(
+    ["reference", "prop_names"],
+    [
+        pytest.param(
+            "/components/schemas/PetExt",
+            {
+                'anotherValue',
+                'name',
+                'tag',
+                'bogus',
+                'flavor',
+                'binString',
+                'optionalList',
+                'firstChoice',
+                'listVarious',
+                'format',
+                'gone',
+                'bestDay',
+                'owner',
+                'inconsistent',
+                'nonListDef',
+            },
+            id="all-of",
+        ),
+        pytest.param(
+            "/components/schemas/MultipleAnyOf",
+            {'anotherValue', 'name', 'tag'},
+            id="any-of",
+        ),
+        pytest.param(
+            "/components/schemas/ShapeShifter",
+            {'species'},
+            id="one-of",
+        ),
+        pytest.param(
+            "#/components/schemas/EnumListProperty",
+            {'rainbow'},
+            id="list",
+        ),
+        pytest.param(
+            "#/components/schemas/MissingItemsModel",
+            {'foo', 'bar'},
+            id="missing-submodel"
+        )
+    ]
+)
+def test_model_properties(reference, prop_names):
+    oas = open_oas(asset_filename("misc.yaml"))
+    uut = PropertyApiGenerator("api_package", oas)
+    model = uut.get_model(reference)
+    body_params = uut.model_properties("foo", model)
+
+    assert prop_names == set(body_params.keys())
+
+
+def test_op_body_arguments():
+    oas = open_oas(asset_filename("misc.yaml"))
+    operations = map_operations(oas.get(OasField.PATHS))
+    op = operations.get("testPathParams")
+    uut = PropertyApiGenerator("api_package", oas)
+    body_params = uut.op_body_top_properties(op)
+
+    args = uut.op_body_arguments(body_params)
+    text = "\n".join(args)
+
+    assert 'name: str = None,  # Pet name' in text
+    assert 'tag: Optional[str] = None,  # Pet classification' in text
+    assert 'another_value: Optional[str] = "Anything goes",  # A string with a default' in text
+    assert 'flavor: Any = None,  # see Species for info' in text
+    assert 'bin_string: Optional[str] = "4",  # choices: 1, 2, 4, 8' in text
+    assert 'optional_list: Any = None,' in text
+    assert 'first_choice: Any = None,' in text
+    assert 'list_various: Any = None,' in text
+    assert 'format_: Optional[str] = "text",' in text
+    assert 'gone: Optional[str] = None,  # To be removed' in text
+    assert 'best_day: Any = None,  # enum buried in all-of' in text
+    assert 'inconsistent: Optional[int] = 2,  # choices: 1, 2, infinity-and-beyond' in text
+    assert 'non_list_def: Any = 1.1,' in text
+
+    # this is filtered out bu the op_body_settable_properties
+    assert 'bogus: Annotated' not in text
+
+    # make sure read-only not included
+    assert 'id: Annotated' not in text
+
+
+def test_function_definition():
+    oas = open_oas(asset_filename("misc.yaml"))
+    item = LayoutNode(command='sna', identifier='snaFooCreate')
+    uut = PropertyApiGenerator("api_package", oas)
+    text = uut.function_definition(item)
+    assert 'def sna_foo_create(' in text
+    assert 'attachments: Optional[list[dict[str, Any]]] = None,  # see Attachment for info' in text
+    assert '# handler for snaFooCreate: POST /sna/foo' in text
+
+    # check infra arguments
+    assert '_api_host: Optional[str] = None,' in text
+    assert '_api_key: Optional[str] = None,' in text
+    assert '_api_timeout: Optional[int] = None,' in text
+    assert '_log_level: Optional[str] = None,' in text
+
+    # check infra initialization/defaults
+    assert '_api_host = _api_host or _e.env_string("API_HOST"' in text
+    assert '_api_key = _api_key or _e.env_string("API_KEY"' in text
+    assert '_api_timeout = _api_timeout or _e.env_int("API_TIMEOUT"' in text
+    assert '_log_level = _log_level or _e.env_string("API_LOG_LEVEL"' in text
+
+    # check the body of the function
+    assert "_l.init_logging(_log_level)" in text
+    assert 'headers = _r.request_headers(_api_key, content_type="application/json")' in text
+    assert 'url = _r.create_url(_api_host, "sna/foo")' in text
+
+    assert 'params = {}' in text
+    assert 'body = {}' in text
+    assert 'if attachments is not None:' in text
+    assert 'body["attachments"] = attachments' in text
+    assert 'data = _r.request("POST", url, headers=headers, params=params, body=body, timeout=_api_timeout)' in text
+
+
+def test_function_deprecated():
+    oas = open_oas(asset_filename("misc.yaml"))
+    item = LayoutNode(command='sna', identifier='snafooCheck')
+    uut = PropertyApiGenerator("api_package", oas)
+    text = uut.function_definition(item)
+
+    assert 'def snafoo_check(' in text
+
+    # check infra arguments
+    assert '_api_host: Optional[str] = None,' in text
+    assert '_api_key: Optional[str] = None,' in text
+    assert '_api_timeout: Optional[int] = None,' in text
+    assert '_log_level: Optional[str] = None,' in text
+
+    # check the warning log
+    assert '_l.logger().warning("snafooCheck is deprecated and should not be used.")' in text
+
+
+def test_function_x_deprecated():
+    oas = open_oas(asset_filename("misc.yaml"))
+    item = LayoutNode(command='sna', identifier='snafooDelete')
+    uut = PropertyApiGenerator("api_package", oas)
+    text = uut.function_definition(item)
+
+    assert 'def snafoo_delete(' in text
+
+    # check infra arguments
+    assert '_api_host: Optional[str] = None,' in text
+    assert '_api_key: Optional[str] = None,' in text
+    assert '_api_timeout: Optional[int] = None,' in text
+    assert '_log_level: Optional[str] = None,' in text
+
+    # check the warning log
+    assert '_l.logger().warning("snafooDelete was deprecated in 3.2.1, and should not be used.")' in text
+
+
+def test_function_header_params():
+    oas = open_oas(asset_filename("misc.yaml"))
+    item = LayoutNode(command='sna', identifier='testPathParams')
+    uut = PropertyApiGenerator("api_package", oas)
+    text = uut.function_definition(item)
+
+    # check that the header enums are defined -- no need to check all the fields of each enum
+    assert 'class Color(str, Enum):' in text
+
+    # check function argument (aka CLI option)
+    assert 'has_param: int = None,  # Parameter in header' in text
+    assert 'color: Optional[Color] = None,' in text
+
+    # make sure we add to headers
+    assert 'user_headers = {}' in text
+    assert 'if has_param is not None:' in text
+    assert 'user_headers["hasParam"] = has_param' in text
+    assert (
+        'headers = _r.request_headers(_api_key, content_type="application/json", **user_headers)'
+        in text
+    )

--- a/tests/assets/misc.yaml
+++ b/tests/assets/misc.yaml
@@ -710,3 +710,7 @@ components:
         - saturday
         - SUNDAY
         - sunday
+    ShapeShifter:
+      oneOf:
+      - $ref: "#/components/schemas/SpeciesProp"
+      - $ref: "#/components/schemas/Attachment"

--- a/tests/cli/test_api_gen.py
+++ b/tests/cli/test_api_gen.py
@@ -147,6 +147,12 @@ def test_api_generate_success_layout(layout, expected_files, temp_working_dir):
             ],
             id="opaque",
         ),
+        pytest.param(
+            "property", [
+                'def create_pets(\n    id: int = None,',
+            ],
+            id="property",
+        ),
     ],
 )
 def test_api_generate_success_body_type(body_type, expected, temp_working_dir):


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Adds another option for amount of request body detail in `api-gen`.  The `opaque` generator is too vague, and the `flat` is too specific -- the `property` splits the difference.

The `property` option takes the first level properties in the request body, but does NOT break them down further.

## CHANGES
<!-- Please explain at a high-level the changes. -->

Added `PropertyApiGenerator` to generate an API with just first level properties from the request body in the function signatures.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->