### PR TITLE
Unify and improve generated API help

### DIFF
--- a/examples/pets-api/pets_api/pets.py
+++ b/examples/pets-api/pets_api/pets.py
@@ -15,10 +15,10 @@ from pets_api import _requests as _r  # noqa: F401
 
 
 def create_pets(
-    id: int = None,
-    name: str = None,
+    id: int = None,  # [required]
+    name: str = None,  # [required]
     tag: Optional[str] = None,
-    owner: str = None,
+    owner: str = None,  # [required]
     _api_host: Optional[str] = None,  # API host, read from API_HOST if not provided, defaults to http://petstore.swagger.io/v1
     _api_key: Optional[str] = None,  # API key for bearer auth, read from API_KEY if not provided
     _api_timeout: Optional[int] = None,  # timeout for operation, read from API_TIMEOUT if not provided, defaults to 5
@@ -50,7 +50,7 @@ def create_pets(
 
 
 def delete_pet_by_id(
-    pet_id: str,  # The id of the pet to retrieve
+    pet_id: str,  # The id of the pet to retrieve [required]
     _api_host: Optional[str] = None,  # API host, read from API_HOST if not provided, defaults to http://petstore.swagger.io/v1
     _api_key: Optional[str] = None,  # API key for bearer auth, read from API_KEY if not provided
     _api_timeout: Optional[int] = None,  # timeout for operation, read from API_TIMEOUT if not provided, defaults to 5
@@ -104,7 +104,7 @@ def list_pets(
 
 
 def show_pet_by_id(
-    pet_id: str,  # The id of the pet to retrieve
+    pet_id: str,  # The id of the pet to retrieve [required]
     _api_host: Optional[str] = None,  # API host, read from API_HOST if not provided, defaults to http://petstore.swagger.io/v1
     _api_key: Optional[str] = None,  # API key for bearer auth, read from API_KEY if not provided
     _api_timeout: Optional[int] = None,  # timeout for operation, read from API_TIMEOUT if not provided, defaults to 5

--- a/openapi_spec_tools/api_gen/api_generator.py
+++ b/openapi_spec_tools/api_gen/api_generator.py
@@ -40,14 +40,27 @@ class ApiGenerator(BaseGenerator, ABC):
 
     def property_help(self, prop: dict[str, Any]) -> str:
         """Get the short help string for the specified property."""
-        text = prop.get(OasField.SUMMARY) or prop.get(OasField.DESCRIPTION)
-        if not text:
+        help = prop.get(OasField.SUMMARY) or prop.get(OasField.DESCRIPTION) or ""
+        short_ref = prop.get(OasField.X_REF)
+        choices = prop.get(OasField.ENUM)
+        required = prop.get(OasField.REQUIRED)
+
+        if help:
+            if len(help) > self.max_help_length:
+                help = help.split(". ")[0].strip()[:self.max_help_length] + '...'
+        elif short_ref:
+            help = f"see {short_ref} for info"
+        elif choices:
+            help = f"choices: {', '.join([str(_) for _ in choices])}"
+
+        if required and "require" not in help.lower():
+            if not help.endswith(" "):
+                help += " "
+            help += "[required]"
+
+        if not help:
             return ""
-
-        if len(text) > self.max_help_length:
-            text = text.split(". ")[0].strip()[:self.max_help_length]
-
-        return f"  # {simple_escape(text)}"
+        return f"  # {simple_escape(help)}"
 
     def standard_imports(self) -> str:
         """Get the standard imports for all CLI modules."""

--- a/openapi_spec_tools/api_gen/property_generator.py
+++ b/openapi_spec_tools/api_gen/property_generator.py
@@ -101,13 +101,10 @@ class PropertyApiGenerator(ApiGenerator):
         """Convert the body parameter dictionary into a list of API function arguments/help."""
         args = []
         for prop_name, prop_data in properties.items():
-            help = self.op_short_help(prop_data)
-            short_ref = prop_data.get(OasField.X_REF)
             required = prop_data.get(OasField.REQUIRED)
             default = prop_data.get(OasField.DEFAULT)
             collection = prop_data.get(OasField.X_COLLECT)
             py_type = self.schema_to_pytype(prop_data)
-            choices = prop_data.get(OasField.ENUM)
             if prop_data.get(OasField.PROPS):
                 py_type = "dict[str, Any]"
             if not py_type:
@@ -119,15 +116,8 @@ class PropertyApiGenerator(ApiGenerator):
                     py_type = f"{collection}[{py_type}]"
                 if not required:
                     py_type = f"Optional[{py_type}]"
-            if help:
-                pass
-            elif short_ref:
-                help = f"see {short_ref} for info"
-            elif choices:
-                help = f"choices: {', '.join([str(_) for _ in choices])}"
-            if required and "required" not in help.lower():
-                help += " [required]"
-            full_help = "" if not help else f"  # {help}"
+
+            full_help = self.property_help(prop_data)
 
             # need to provide a default, since it may come AFTER option parameters with defaults
             args.append(f"{self.variable_name(prop_name)}: {py_type} = {maybe_quoted(default)},{full_help}")

--- a/tests/api_gen/constants.py
+++ b/tests/api_gen/constants.py
@@ -10,6 +10,7 @@ ANY_OF = "anyOf"
 ONE_OF = "oneOf"
 ITEMS = "items"
 DEF = "default"
+X_REF = "x-reference"
 
 S1 = '\n    '
 S2 = f"{S1}    "

--- a/tests/api_gen/test_api_generator.py
+++ b/tests/api_gen/test_api_generator.py
@@ -4,7 +4,10 @@ from openapi_spec_tools.types import OasField
 from openapi_spec_tools.utils import map_operations
 from openapi_spec_tools.utils import open_oas
 from tests.api_gen.constants import DESC
+from tests.api_gen.constants import ENUM
+from tests.api_gen.constants import REQUIRED
 from tests.api_gen.constants import SUM
+from tests.api_gen.constants import X_REF
 from tests.api_gen.helpers import TestApiGenerator
 from tests.helpers import asset_filename
 
@@ -16,8 +19,14 @@ from tests.helpers import asset_filename
         pytest.param({SUM: "Short summary. With sentence."}, 50, "  # Short summary. With sentence.", id="sum-sent"),
         pytest.param({DESC: "Short desc. With sentence."}, 50, "  # Short desc. With sentence.", id="desc-sent"),
         pytest.param({DESC: "Description", SUM: "Summary"}, 50, "  # Summary", id="both"),
-        pytest.param({SUM: "Short summary. With sentence."}, 25, "  # Short summary", id="sentence"),
-        pytest.param({SUM: "Short summary. With sentence."}, 10, "  # Short summ", id="truncated"),
+        pytest.param({SUM: "Short summary. With sentence."}, 25, "  # Short summary...", id="sentence"),
+        pytest.param({SUM: "Short summary. With sentence."}, 10, "  # Short summ...", id="truncated"),
+        pytest.param({REQUIRED: True, SUM: "some help"}, 100, "  # some help [required]", id="required"),
+        pytest.param({REQUIRED: True, SUM: "Requires some help"}, 100, "  # Requires some help", id="req-desc"),
+        pytest.param({REQUIRED: True}, 100, "  # [required]", id="req-only"),
+        pytest.param({REQUIRED: True, X_REF: "RefName"}, 100, "  # see RefName for info [required]", id="req-ref"),
+        pytest.param({ENUM: ["a", "t", 0]}, 100, "  # choices: a, t, 0", id="enum"),
+        pytest.param({X_REF: "ShortReferenceName"}, 100, "  # see ShortReferenceName for info", id="ref")
     ]
 )
 def test_property_help(prop, max_len, expected):


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

The flat and property API generators had different help strings when they should have similar help strings. 

## CHANGES
<!-- Please explain at a high-level the changes. -->

Improves the output of `ApiGenerator.property_help()`, and updates the `PropertyApiGenerator` to use that function.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->