### PR TITLE
Add oas-history utilities

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,6 +34,8 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/openapi_spec_tools/cli/arguments.py
+++ b/openapi_spec_tools/cli/arguments.py
@@ -4,6 +4,8 @@ from typing import Annotated
 from typing import Optional
 
 import typer
+from rich_objects import OutputFormat
+from rich_objects import OutputStyle
 
 DIRECTORY = "DIRECTORY"
 FILENAME = "FILENAME"
@@ -61,9 +63,33 @@ LogLevelOption = Annotated[
         help="Log level",
     ),
 ]
+MaxCountOption = Annotated[
+    Optional[int],
+    typer.Option(
+        "--max",
+        "--max-count",
+        help="Maximum number of items to get (if any)."
+    )
+]
 OpenApiFilenameArgument = Annotated[
     str,
     typer.Argument(metavar=FILENAME, show_default=False, help="OpenAPI specification filename"),
+]
+OutputFormatOption = Annotated[
+    OutputFormat,
+    typer.Option(
+        "--format",
+        case_sensitive=False,
+        help="Output format style",
+    ),
+]
+OutputStyleOption = Annotated[
+    OutputStyle,
+    typer.Option(
+        "--style",
+        case_sensitive=False,
+        help="Style for output",
+    ),
 ]
 PackageNameArgument = Annotated[str, typer.Argument(metavar="PACKAGE", show_default=False, help="Base package name")]
 PathPrefixOption = Annotated[
@@ -80,4 +106,3 @@ UpdatedOpenApiFilenameOption = Annotated[
         help="Filename for updated OpenAPI spec, overwrites original of not specified.",
     ),
 ]
-

--- a/openapi_spec_tools/cli/history.py
+++ b/openapi_spec_tools/cli/history.py
@@ -46,7 +46,7 @@ def _with_timezone(dt: datetime | None) -> datetime | None:
 
 
 def _read_data(commit: git.Commit, file: str) -> dict[str, Any]:
-    relative_path = Path(file).absolute().relative_to(commit.tree.abspath)
+    relative_path = Path(file).absolute().relative_to(commit.tree.abspath).as_posix()
     target_file = commit.tree / relative_path
     data = target_file.data_stream.read().decode("utf-8")
     # NOTE: handles when data is JSON, so no special handling necessary

--- a/openapi_spec_tools/cli/history.py
+++ b/openapi_spec_tools/cli/history.py
@@ -23,7 +23,6 @@ from openapi_spec_tools.cli.arguments import OutputStyleOption
 from openapi_spec_tools.utils import find_diffs
 
 app = typer.Typer(name="history", no_args_is_help=True, short_help="Git history of OAS file")
-LOG_CLASS = "history"
 
 
 AuthorOption = Annotated[
@@ -42,10 +41,16 @@ StartDateOption = Annotated[
 
 
 def _with_timezone(dt: datetime | None) -> datetime | None:
+    """Set the timezone to UTC when no timezone it provided.
+
+    The git datetime values include a timezone, and comparison to datetime objects without a
+    timezone does not work.
+    """
     return dt if not dt or dt.tzinfo else dt.replace(tzinfo=timezone.utc)
 
 
 def _read_data(commit: git.Commit, file: str) -> dict[str, Any]:
+    """Read the file from the commit into a dictionary."""
     relative_path = Path(file).absolute().relative_to(commit.tree.abspath).as_posix()
     target_file = commit.tree / relative_path
     data = target_file.data_stream.read().decode("utf-8")
@@ -54,6 +59,7 @@ def _read_data(commit: git.Commit, file: str) -> dict[str, Any]:
 
 
 def _author_match(commit: git.Commit, author: str) -> bool:
+    """Check if the author is part of the commit."""
     needle = author.lower()
     if needle in commit.author.name.lower() or needle in commit.author.email:
         return True
@@ -72,6 +78,7 @@ def _find_commits(
     author: Optional[str] = None,
     max_count: Optional[int] = None,
 ) -> list[git.Commit]:
+    """Get a list of commits for the provided file and parameters."""
     repo = git.Repo(oas_file, search_parent_directories=True)
 
     commits = list(repo.iter_commits(paths=oas_file))

--- a/openapi_spec_tools/cli/history.py
+++ b/openapi_spec_tools/cli/history.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Implement the 'oas-history' CLI commands."""
+from datetime import datetime
+from datetime import timezone
+from pathlib import Path
+from typing import Annotated
+from typing import Any
+from typing import Optional
+
+import git
+import typer
+import yaml
+from rich_objects import TableConfig
+from rich_objects import console_factory
+from rich_objects import display
+
+from openapi_spec_tools.cli.arguments import MaxCountOption
+from openapi_spec_tools.cli.arguments import OpenApiFilenameArgument
+from openapi_spec_tools.cli.arguments import OutputFormat
+from openapi_spec_tools.cli.arguments import OutputFormatOption
+from openapi_spec_tools.cli.arguments import OutputStyle
+from openapi_spec_tools.cli.arguments import OutputStyleOption
+from openapi_spec_tools.utils import find_diffs
+
+app = typer.Typer(name="history", no_args_is_help=True, short_help="Git history of OAS file")
+LOG_CLASS = "history"
+
+
+AuthorOption = Annotated[
+    Optional[str],
+    typer.Option("--author", show_default=False, help="Name, or partial name, of author or coauthor (case insensitive)")
+]
+EndDateOption = Annotated[
+    Optional[datetime],
+    typer.Option("--end", show_default=False, help="Date/time of latest commit.")
+]
+StartDateOption = Annotated[
+    Optional[datetime],
+    typer.Option("--start", show_default=False, help="Date/time of first commit.")
+]
+
+
+
+def _with_timezone(dt: datetime | None) -> datetime | None:
+    return dt if not dt or dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+def _read_data(commit: git.Commit, file: str) -> dict[str, Any]:
+    relative_path = Path(file).absolute().relative_to(commit.tree.abspath)
+    target_file = commit.tree / relative_path
+    data = target_file.data_stream.read().decode("utf-8")
+    # NOTE: handles when data is JSON, so no special handling necessary
+    return yaml.safe_load(data)
+
+
+def _author_match(commit: git.Commit, author: str) -> bool:
+    needle = author.lower()
+    if needle in commit.author.name.lower() or needle in commit.author.email:
+        return True
+
+    for coauth in commit.co_authors:  # pragma: no cover
+        if needle in coauth.name.lower() or needle in coauth.email:
+            return True
+
+    return False
+
+
+def _find_commits(
+    oas_file: str,
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+    author: Optional[str] = None,
+    max_count: Optional[int] = None,
+) -> list[git.Commit]:
+    repo = git.Repo(oas_file, search_parent_directories=True)
+
+    commits = list(repo.iter_commits(paths=oas_file))
+    if start:
+        commits = [_ for _ in commits if _.committed_datetime >= start]
+    if end:
+        commits = [_ for _ in commits if _.committed_datetime <= end]
+    if author:
+        commits = [_ for _ in commits if _author_match(_, author=author)]
+    if max_count:
+        commits = commits[:max_count]
+
+    return commits
+
+
+@app.command("commits", short_help="Show git history of the specified OAS file.")
+def commit_history(
+    oas_file: OpenApiFilenameArgument,
+    start: StartDateOption = None,
+    end: EndDateOption = None,
+    author: AuthorOption = None,
+    max_count: MaxCountOption = 30,
+    out_fmt: OutputFormatOption = OutputFormat.TABLE,
+    out_style: OutputStyleOption = OutputStyle.ALL,
+):
+    """Show git history of the specific OAS file over with the provided search parameters."""
+    start = _with_timezone(start)
+    end = _with_timezone(end)
+    commits = _find_commits(
+        oas_file=oas_file,
+        start=start,
+        end=end,
+        author=author,
+        max_count=max_count,
+    )
+    console = console_factory()
+    if not commits:
+        console.print("No commits found.")
+        return
+
+    columns = ["date", "commit", "*"]
+    data = [
+        {
+            "date": _.authored_datetime.date().isoformat(),
+            "commit": _.hexsha[:7],
+            "author": _.author.name,
+            "message": _.message.strip()[:100],
+        }
+        for _ in commits
+    ]
+    display(data, fmt=out_fmt, style=out_style, columns=columns, console=console)
+    return
+
+
+@app.command("changes", short_help="Show OAS changes over git history.")
+def commit_changes(
+    oas_file: OpenApiFilenameArgument,
+    start: StartDateOption = None,
+    end: EndDateOption = None,
+    author: AuthorOption = None,
+    max_count: MaxCountOption = 30,
+    out_fmt: OutputFormatOption = OutputFormat.TABLE,
+    out_style: OutputStyleOption = OutputStyle.ALL,
+):
+    """Show OAS changes over the history of the provided search. The ."""
+    start = _with_timezone(start)
+    end = _with_timezone(end)
+    # NOTE: do not filter out commits by other authors, or before start, or will get odd comparisons
+    commits = _find_commits(
+        oas_file=oas_file,
+        end=end,
+    )
+    columns = ["date", "commit", "changes"]
+    data = []
+    prev_comm = commits[0]
+    prev_data = _read_data(prev_comm, oas_file)
+    for curr_comm in commits[1:]:
+        curr_data = _read_data(curr_comm, oas_file)
+        if not author or _author_match(prev_comm, author):
+            # because we're walking backward chronologicallly, the prev/curr are different order
+            changes = find_diffs(curr_data, prev_data)
+            if out_fmt == OutputFormat.TABLE:
+                # YAML format is the best looking format for the diffs in a table, so force it
+                changes = yaml.dump(changes).strip()
+            data.append(
+                {
+                    "date": prev_comm.authored_datetime.date().isoformat(),
+                    "commit": prev_comm.hexsha[:7],
+                    "changes": changes,
+                }
+            )
+
+        # check whether we've hit the last entry
+        if len(data) == max_count or (start and curr_comm.authored_datetime < start):
+            break
+
+        prev_data = curr_data
+        prev_comm = curr_comm
+
+    console = console_factory()
+    if not data:
+        console.print("No differences found with those parameters.")
+        return
+
+    config = TableConfig(value_max_len=1000)
+    display(data, fmt=out_fmt, style=out_style, columns=columns, config=config, console=console)
+    return
+
+
+if __name__ == "__main__":
+    app()

--- a/openapi_spec_tools/cli/oas.py
+++ b/openapi_spec_tools/cli/oas.py
@@ -14,6 +14,7 @@ from rich_objects import console_factory
 from openapi_spec_tools.cli.arguments import LogLevelOption
 from openapi_spec_tools.cli.arguments import OpenApiFilenameArgument
 from openapi_spec_tools.cli.arguments import UpdatedOpenApiFilenameOption
+from openapi_spec_tools.cli.history import app as history_app
 from openapi_spec_tools.cli.utils import error_out
 from openapi_spec_tools.cli.utils import init_logging
 from openapi_spec_tools.cli.utils import open_oas_with_error_handling
@@ -75,6 +76,7 @@ app = typer.Typer(
     short_help="OpenAPI specification tools",
     help="Various utilities for inspecting, analyzing and modifying OpenAPI specifications.",
 )
+app.add_typer(history_app, name="history")
 
 
 @app.command("info", short_help="Display the 'info' from the OpenAPI specification")

--- a/poetry.lock
+++ b/poetry.lock
@@ -395,6 +395,40 @@ typing-extensions = {version = ">=4.6.0", markers = "python_version < \"3.13\""}
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "gitdb"
+version = "4.0.12"
+description = "Git Object Database"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf"},
+    {file = "gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571"},
+]
+
+[package.dependencies]
+smmap = ">=3.0.1,<6"
+
+[[package]]
+name = "gitpython"
+version = "3.1.46"
+description = "GitPython is a Python library used to interact with Git repositories"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058"},
+    {file = "gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f"},
+]
+
+[package.dependencies]
+gitdb = ">=4.0.1,<5"
+
+[package.extras]
+doc = ["sphinx (>=7.1.2,<7.2)", "sphinx-autodoc-typehints", "sphinx_rtd_theme"]
+test = ["coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock", "mypy (==1.18.2)", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions"]
+
+[[package]]
 name = "idna"
 version = "3.11"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -958,6 +992,18 @@ files = [
 ]
 
 [[package]]
+name = "smmap"
+version = "5.0.3"
+description = "A pure Python implementation of a sliding window memory map manager"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f"},
+    {file = "smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c"},
+]
+
+[[package]]
 name = "tomli"
 version = "2.4.1"
 description = "A lil' TOML parser"
@@ -1094,4 +1140,4 @@ zstd = ["backports-zstd (>=1.0.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "c2b7b4b0c2dfd53bf07e1d300c54cba70c821b704b34be8fdd9c5510df0c2275"
+content-hash = "b110216b1a7f8d14794b2628d0c273809fdbf51de951a8a4323108fce6ac007d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ rich = "^14.3.3"
 requests = "^2.32.5"
 pydantic = "^2.12.5"
 rich-objects = "^0.2.3"
+gitpython = "^3.1.46"
 
 [tool.poetry.scripts]
 oas = "openapi_spec_tools.cli.oas:app"

--- a/tests/cli/test_history.py
+++ b/tests/cli/test_history.py
@@ -1,0 +1,302 @@
+import json
+from datetime import datetime
+from datetime import timezone
+from pathlib import Path
+from typing import Any
+from typing import Optional
+from unittest import mock
+
+import pytest
+
+from openapi_spec_tools.cli.history import _find_commits
+from openapi_spec_tools.cli.history import _read_data
+from openapi_spec_tools.cli.history import commit_changes
+from openapi_spec_tools.cli.history import commit_history
+from tests.helpers import StringIo
+from tests.helpers import asset_filename
+
+# NOTE: dates are specified to avoid needing test updates in the future
+START = datetime(2025, 1, 1, tzinfo=timezone.utc)
+END = datetime(2026, 3, 1, tzinfo=timezone.utc)
+
+
+@pytest.mark.parametrize(
+    ["asset_name", "start", "end", "author", "max_count", "expected"],
+    [
+        pytest.param("pet.yaml", None, None, None, None, {'46370d4'}, id="single"),
+        pytest.param("pet.yaml", START, END, None, None, {'46370d4'}, id="in-range"),
+        pytest.param("pet.yaml", END, None, None, None, set(), id="too-early"),
+        pytest.param("pet.yaml", None, START, None, None, set(), id="too-late"),
+        pytest.param("pet.yaml", None, None, "RicK PorTer", None, {'46370d4'}, id="author-name"),
+        pytest.param("pet.yaml", None, None, "rickwporter", None, {'46370d4'}, id="author-email"),
+        pytest.param("pet.yaml", None, None, "rickXporter", None, set(), id="author-not-found"),
+        pytest.param("pet2.yaml", None, None, None, None, {'502a33f', 'b8121dd', '65d346f'}, id="several"),
+        pytest.param("pet2.yaml", None, None, None, 10, {'502a33f', 'b8121dd', '65d346f'}, id="max-ten"),
+        pytest.param("pet2.yaml", None, None, None, 2, {'502a33f', 'b8121dd'}, id="max-two"),
+    ]
+)
+def test_find_commits(
+    asset_name: str,
+    start: Optional[datetime],
+    end: Optional[datetime],
+    author: Optional[str],
+    max_count: Optional[int],
+    expected: set[str],
+) -> None:
+    commits = _find_commits(asset_filename(asset_name), start=start, end=end, author=author, max_count=max_count)
+    ids = {_.hexsha[:7] for _ in commits}
+    assert ids == expected
+
+
+def test_read_data() -> None:
+    # no diffs to test reading, so just directly using a JSON file
+    json_file = asset_filename("pet2.json")
+    commits = _find_commits(json_file)
+    commit_data = _read_data(commits[0], json_file)
+    file_data = json.load(Path(json_file).open())
+    assert commit_data == file_data
+
+
+PETS2_HISTORY_TABLE = """\
+┏━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Date       ┃ Commit  ┃ Properties                                   ┃
+┡━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ 2025-04-12 │ 502a33f │  author   Rick Porter                        │
+│            │         │  message  Add exception handling             │
+├────────────┼─────────┼──────────────────────────────────────────────┤
+│ 2025-04-12 │ b8121dd │  author   Rick Porter                        │
+│            │         │  message  Add min/max support for int/float  │
+├────────────┼─────────┼──────────────────────────────────────────────┤
+│ 2025-02-02 │ 65d346f │  author   Rick Porter                        │
+│            │         │  message  Another test asset                 │
+└────────────┴─────────┴──────────────────────────────────────────────┘
+"""
+PETS2_HISTORY_YAML = """\
+- author: Rick Porter
+  commit: 502a33f
+  date: '2025-04-12'
+  message: Add exception handling
+- author: Rick Porter
+  commit: b8121dd
+  date: '2025-04-12'
+  message: Add min/max support for int/float
+- author: Rick Porter
+  commit: 65d346f
+  date: '2025-02-02'
+  message: Another test asset
+
+"""
+PETS2_HISTORY_JSON = """\
+[
+  {
+    "date": "2025-04-12",
+    "commit": "502a33f",
+    "author": "Rick Porter",
+    "message": "Add exception handling"
+  },
+  {
+    "date": "2025-04-12",
+    "commit": "b8121dd",
+    "author": "Rick Porter",
+    "message": "Add min/max support for int/float"
+  },
+  {
+    "date": "2025-02-02",
+    "commit": "65d346f",
+    "author": "Rick Porter",
+    "message": "Another test asset"
+  }
+]
+"""
+NO_COMMITS = """\
+No commits found.
+"""
+@pytest.mark.parametrize(
+    ["args", "expected"],
+    [
+        pytest.param(
+            {"oas_file": asset_filename("pet2.yaml"), "start": START, "end": END, "out_fmt": "table"},
+            PETS2_HISTORY_TABLE,
+            id="table",
+        ),
+        pytest.param(
+            {"oas_file": asset_filename("pet2.yaml"), "start": START, "end": END, "out_fmt": "yaml"},
+            PETS2_HISTORY_YAML,
+            id="yaml",
+        ),
+        pytest.param(
+            {"oas_file": asset_filename("pet2.yaml"), "start": START, "end": END, "out_fmt": "json"},
+            PETS2_HISTORY_JSON,
+            id="json",
+        ),
+        pytest.param(
+            {"oas_file": asset_filename("pet2.yaml"), "author": "john"},
+            NO_COMMITS,
+            id="no-author",
+        ),
+    ]
+)
+def test_commit_history(args: dict[str, Any], expected: str) -> None:
+    with (
+        mock.patch('sys.stdout', new_callable=StringIo) as mock_stdout,
+    ):
+        commit_history(**args)
+
+    result = mock_stdout.getvalue()
+    assert result == expected
+
+PETS2_CHANGES_TABLE = """\
+┏━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Date       ┃ Commit  ┃ Changes                    ┃
+┡━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ 2025-04-12 │ 502a33f │ paths:                     │
+│            │         │   /pets:                   │
+│            │         │     get:                   │
+│            │         │       parameters[0]:       │
+│            │         │         schema:            │
+│            │         │           minimum: removed │
+├────────────┼─────────┼────────────────────────────┤
+│ 2025-04-12 │ b8121dd │ paths:                     │
+│            │         │   /pets:                   │
+│            │         │     get:                   │
+│            │         │       parameters[0]:       │
+│            │         │         schema:            │
+│            │         │           minimum: added   │
+└────────────┴─────────┴────────────────────────────┘
+"""
+PETS2_CHANGES_YAML = """\
+- changes:
+    paths:
+      /pets:
+        get:
+          parameters[0]:
+            schema:
+              minimum: removed
+  commit: 502a33f
+  date: '2025-04-12'
+- changes:
+    paths:
+      /pets:
+        get:
+          parameters[0]:
+            schema:
+              minimum: added
+  commit: b8121dd
+  date: '2025-04-12'
+
+"""
+PETS2_CHANGES_JSON = """\
+[
+  {
+    "date": "2025-04-12",
+    "commit": "502a33f",
+    "changes": {
+      "paths": {
+        "/pets": {
+          "get": {
+            "parameters[0]": {
+              "schema": {
+                "minimum": "removed"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "date": "2025-04-12",
+    "commit": "b8121dd",
+    "changes": {
+      "paths": {
+        "/pets": {
+          "get": {
+            "parameters[0]": {
+              "schema": {
+                "minimum": "added"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+]
+"""
+NO_DIFFS = """\
+No differences found with those parameters.
+"""
+MISC_YAML_CHANGES = """\
+- changes:
+    paths:
+      /pets/{numFeet}/{species}/{neutered}/{birthday}:
+        get:
+          parameters: 'different lengths: 17 != 18'
+  commit: 31676f5
+  date: '2025-07-08'
+
+"""
+@pytest.mark.parametrize(
+    ["args", "expected"],
+    [
+        pytest.param(
+            {
+                "oas_file": asset_filename("pet2.yaml"),
+                "start": START,
+                "end": END,
+                "out_fmt": "table",
+            },
+            PETS2_CHANGES_TABLE,
+            id="table",
+        ),
+        pytest.param(
+            {
+                "oas_file": asset_filename("pet2.yaml"),
+                "start": START,
+                "end": END,
+                "out_fmt": "yaml"
+            },
+            PETS2_CHANGES_YAML,
+            id="yaml",
+        ),
+        pytest.param(
+            {
+                "oas_file": asset_filename("pet2.yaml"),
+                "start": START,
+                "end": END,
+                "out_fmt": "json",
+            },
+            PETS2_CHANGES_JSON,
+            id="json",
+        ),
+        pytest.param(
+            {
+                "oas_file": asset_filename("pet2.yaml"),
+                "author": "fred",
+                "start": START,
+                "end": END,
+                "out_fmt": "json",
+            },
+            NO_DIFFS,
+            id="no-author",
+        ),
+        pytest.param(
+            {
+                "oas_file": asset_filename("misc.yaml"),
+                "start": datetime(2025, 7, 14, tzinfo=timezone.utc),
+                "end": datetime(2025, 7, 10),
+                "out_fmt": "yaml"
+            },
+            MISC_YAML_CHANGES,
+            id="late-start",
+        ),
+    ]
+)
+def test_commit_changes(args: dict[str, Any], expected: str) -> None:
+    with (
+        mock.patch('sys.stdout', new_callable=StringIo) as mock_stdout,
+    ):
+        commit_changes(**args)
+
+    result = mock_stdout.getvalue()
+    assert result == expected

--- a/tests/cli/test_history.py
+++ b/tests/cli/test_history.py
@@ -12,6 +12,7 @@ from openapi_spec_tools.cli.history import _find_commits
 from openapi_spec_tools.cli.history import _read_data
 from openapi_spec_tools.cli.history import commit_changes
 from openapi_spec_tools.cli.history import commit_history
+from tests.cli_gen.helpers import to_ascii
 from tests.helpers import StringIo
 from tests.helpers import asset_filename
 
@@ -143,7 +144,7 @@ def test_commit_history(args: dict[str, Any], expected: str) -> None:
         commit_history(**args)
 
     result = mock_stdout.getvalue()
-    assert result == expected
+    assert to_ascii(result) == to_ascii(expected)
 
 PETS2_CHANGES_TABLE = """\
 ┏━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
@@ -299,4 +300,4 @@ def test_commit_changes(args: dict[str, Any], expected: str) -> None:
         commit_changes(**args)
 
     result = mock_stdout.getvalue()
-    assert result == expected
+    assert to_ascii(result) == to_ascii(expected)


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Add `oas history` CLI to inspect the Git history of an OAS file. 

## CHANGES
<!-- Please explain at a high-level the changes. -->

Added `gitpython` package to project.
Added some "common" arguments to `openapi_spec_tools.cli.arguments`.
Added `openapi_spec_tools.cli.history` and related tests
Added link from `oas` to `oas history`.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->