### PR TITLE
Improve user feedback when file is present, or in git

### DIFF
--- a/openapi_spec_tools/cli/history.py
+++ b/openapi_spec_tools/cli/history.py
@@ -20,6 +20,7 @@ from openapi_spec_tools.cli.arguments import OutputFormat
 from openapi_spec_tools.cli.arguments import OutputFormatOption
 from openapi_spec_tools.cli.arguments import OutputStyle
 from openapi_spec_tools.cli.arguments import OutputStyleOption
+from openapi_spec_tools.cli.utils import error_out
 from openapi_spec_tools.utils import find_diffs
 
 app = typer.Typer(name="history", no_args_is_help=True, short_help="Git history of OAS file")
@@ -94,6 +95,17 @@ def _find_commits(
     return commits
 
 
+def _assert_exists(file: str) -> None:
+    """Assert that the file exists in the git repo, or throw an exception."""
+    try:
+        repo = git.Repo(file, search_parent_directories=True)
+        commit = repo.head.commit
+        relative_path = Path(file).absolute().relative_to(commit.tree.abspath).as_posix()
+        _ = commit.tree / relative_path
+    except Exception:
+        error_out("Unable to find file")
+
+
 @app.command("commits", short_help="Show git history of the specified OAS file.")
 def commit_history(
     oas_file: OpenApiFilenameArgument,
@@ -105,6 +117,7 @@ def commit_history(
     out_style: OutputStyleOption = OutputStyle.ALL,
 ):
     """Show git history of the specific OAS file over with the provided search parameters."""
+    _assert_exists(oas_file)
     start = _with_timezone(start)
     end = _with_timezone(end)
     commits = _find_commits(
@@ -144,6 +157,7 @@ def commit_changes(
     out_style: OutputStyleOption = OutputStyle.ALL,
 ):
     """Show OAS changes over the history of the provided search. The ."""
+    _assert_exists(oas_file)
     start = _with_timezone(start)
     end = _with_timezone(end)
     # NOTE: do not filter out commits by other authors, or before start, or will get odd comparisons

--- a/tests/cli/test_history.py
+++ b/tests/cli/test_history.py
@@ -7,6 +7,7 @@ from typing import Optional
 from unittest import mock
 
 import pytest
+import typer
 
 from openapi_spec_tools.cli.history import _find_commits
 from openapi_spec_tools.cli.history import _read_data
@@ -19,6 +20,7 @@ from tests.helpers import asset_filename
 # NOTE: dates are specified to avoid needing test updates in the future
 START = datetime(2025, 1, 1, tzinfo=timezone.utc)
 END = datetime(2026, 3, 1, tzinfo=timezone.utc)
+FILE_ERROR = "ERROR: Unable to find file\n"
 
 
 @pytest.mark.parametrize(
@@ -137,7 +139,7 @@ No commits found.
         ),
     ]
 )
-def test_commit_history(args: dict[str, Any], expected: str) -> None:
+def test_commit_history_success(args: dict[str, Any], expected: str) -> None:
     with (
         mock.patch('sys.stdout', new_callable=StringIo) as mock_stdout,
     ):
@@ -145,6 +147,19 @@ def test_commit_history(args: dict[str, Any], expected: str) -> None:
 
     result = mock_stdout.getvalue()
     assert to_ascii(result) == to_ascii(expected)
+
+
+def test_commit_history_failure() -> None:
+    with (
+        mock.patch('sys.stdout', new_callable=StringIo) as mock_stdout,
+        pytest.raises(typer.Exit) as context,
+    ):
+        commit_history(asset_filename("foo.yaml"))
+
+    ex = context.value
+    assert ex.exit_code == 1
+    assert FILE_ERROR == mock_stdout.getvalue()
+
 
 PETS2_CHANGES_TABLE = """\
 ┏━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
@@ -293,7 +308,7 @@ MISC_YAML_CHANGES = """\
         ),
     ]
 )
-def test_commit_changes(args: dict[str, Any], expected: str) -> None:
+def test_commit_changes_success(args: dict[str, Any], expected: str) -> None:
     with (
         mock.patch('sys.stdout', new_callable=StringIo) as mock_stdout,
     ):
@@ -301,3 +316,15 @@ def test_commit_changes(args: dict[str, Any], expected: str) -> None:
 
     result = mock_stdout.getvalue()
     assert to_ascii(result) == to_ascii(expected)
+
+
+def test_commit_changes_failure() -> None:
+    with (
+        mock.patch('sys.stdout', new_callable=StringIo) as mock_stdout,
+        pytest.raises(typer.Exit) as context,
+    ):
+        commit_changes(asset_filename("foo.yaml"))
+
+    ex = context.value
+    assert ex.exit_code == 1
+    assert FILE_ERROR == mock_stdout.getvalue()


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

The traceback for a file that was not found was ugly -- this provides a cleaner user experience.

## CHANGES
<!-- Please explain at a high-level the changes. -->

Introduce `_assert_exits()` that provides easier to read feedback when a repo or file is not found.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->