### PR TITLE
Install poetry before python in github actions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,10 +18,10 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
       - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
       - name: Install poetry
         uses: abatilo/actions-poetry@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
       - name: Install the project dependencies
         run: poetry install
       - name: Lint (poetry ruff)

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Install poetry
         uses: abatilo/actions-poetry@v4
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
       - name: Install the project dependencies
         run: poetry install
       - name: Lint (poetry ruff)

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
       - uses: actions/checkout@v4
       - name: Install poetry
-        uses: abatilo/actions-poetry@v4
+        run: pipx install poetry
       - name: Set up Python
         uses: actions/setup-python@v5
       - name: Install the project dependencies

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
       - uses: actions/checkout@v4
       - name: Install poetry
-        run: pipx install poetry
+        uses: snok/install-poetry@v1
       - name: Set up Python
         uses: actions/setup-python@v5
       - name: Install the project dependencies

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
       - uses: actions/checkout@v4
       - name: Install poetry
-        uses: snok/install-poetry@v1
+        uses: abatilo/actions-poetry@v4
       - name: Set up Python
         uses: actions/setup-python@v5
       - name: Install the project dependencies

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
       - uses: actions/checkout@v4
       - name: Install poetry
-        uses: abatilo/actions-poetry@v4
+        uses: snok/install-poetry@v1
       - name: Set up Python
         uses: actions/setup-python@v6
       - name: Install the project dependencies

--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install poetry
-        uses: abatilo/actions-poetry@v4
+        run: pipx install poetry
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: abatilo/actions-poetry@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
 
       - name: Install the project dependencies
         run: poetry install

--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install poetry
-        uses: abatilo/actions-poetry@v4
+        uses: snok/install-poetry@v1
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install poetry
-        run: pipx install poetry
+        uses: snok/install-poetry@v1
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -27,11 +27,11 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-
       - name: Install poetry
         uses: abatilo/actions-poetry@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
 
       - name: Install the project dependencies
         run: poetry install

--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install poetry
-        uses: snok/install-poetry@v1
+        uses: abatilo/actions-poetry@v4
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/regenerate.yaml
+++ b/.github/workflows/regenerate.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Install poetry
         uses: abatilo/actions-poetry@v4
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
       - name: Install the project dependencies
         run: poetry install
       - name: Regenerate

--- a/.github/workflows/regenerate.yaml
+++ b/.github/workflows/regenerate.yaml
@@ -18,10 +18,10 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
       - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
       - name: Install poetry
         uses: abatilo/actions-poetry@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
       - name: Install the project dependencies
         run: poetry install
       - name: Regenerate

--- a/.github/workflows/regenerate.yaml
+++ b/.github/workflows/regenerate.yaml
@@ -19,7 +19,7 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
       - uses: actions/checkout@v4
       - name: Install poetry
-        uses: abatilo/actions-poetry@v4
+        run: pipx install poetry
       - name: Set up Python
         uses: actions/setup-python@v5
       - name: Install the project dependencies

--- a/.github/workflows/regenerate.yaml
+++ b/.github/workflows/regenerate.yaml
@@ -19,7 +19,7 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
       - uses: actions/checkout@v4
       - name: Install poetry
-        run: pipx install poetry
+        uses: snok/install-poetry@v1
       - name: Set up Python
         uses: actions/setup-python@v5
       - name: Install the project dependencies

--- a/.github/workflows/regenerate.yaml
+++ b/.github/workflows/regenerate.yaml
@@ -19,7 +19,7 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
       - uses: actions/checkout@v4
       - name: Install poetry
-        uses: snok/install-poetry@v1
+        uses: abatilo/actions-poetry@v4
       - name: Set up Python
         uses: actions/setup-python@v5
       - name: Install the project dependencies

--- a/.github/workflows/regenerate.yaml
+++ b/.github/workflows/regenerate.yaml
@@ -19,7 +19,7 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
       - uses: actions/checkout@v4
       - name: Install poetry
-        uses: abatilo/actions-poetry@v4
+        uses: snok/install-poetry@v1
       - name: Set up Python
         uses: actions/setup-python@v6
       - name: Install the project dependencies

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -75,10 +75,6 @@ jobs:
           python-version: '3.12'
       - name: Install poetry
         uses: abatilo/actions-poetry@v4
-      - name: Setup a virtual environment
-        run: |
-          poetry config virtualenvs.create true --local
-          poetry config virtualenvs.in-project true --local
       - name: Install the project dependencies
         run: poetry install
       - name: Get coverage files

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install poetry
-        run: pipx install poetry
+        uses: snok/install-poetry@v1
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -78,7 +78,7 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install poetry
-        run: pipx install poetry
+        uses: snok/install-poetry@v1
       - name: Setup a virtual environment
         run: |
           poetry config virtualenvs.create true --local

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,11 +70,11 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
       - uses: actions/checkout@v4
+      - name: Install poetry
+        uses: abatilo/actions-poetry@v4
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
-      - name: Install poetry
-        uses: abatilo/actions-poetry@v4
       - name: Install the project dependencies
         run: poetry install
       - name: Get coverage files

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install poetry
-        uses: abatilo/actions-poetry@v4
+        uses: snok/install-poetry@v1
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -71,7 +71,7 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
       - uses: actions/checkout@v4
       - name: Install poetry
-        uses: abatilo/actions-poetry@v4
+        uses: snok/install-poetry@v1
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install poetry
-        uses: abatilo/actions-poetry@v4
+        run: pipx install poetry
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -78,7 +78,7 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install poetry
-        uses: abatilo/actions-poetry@v4
+        run: pipx install poetry
       - name: Setup a virtual environment
         run: |
           poetry config virtualenvs.create true --local

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install poetry
-        uses: snok/install-poetry@v1
+        uses: abatilo/actions-poetry@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -74,7 +74,7 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install poetry
-        uses: snok/install-poetry@v1
+        uses: abatilo/actions-poetry@v4
       - name: Setup a virtual environment
         run: |
           poetry config virtualenvs.create true --local

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,12 +36,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Install poetry
+        uses: abatilo/actions-poetry@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install poetry
-        uses: abatilo/actions-poetry@v4
       - name: Setup a virtual environment
         run: |
           poetry config virtualenvs.create true --local

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Install poetry
         uses: abatilo/actions-poetry@v4
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - uses: actions/cache@v3
@@ -70,7 +70,7 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - name: Install poetry

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,10 +42,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Setup a virtual environment
-        run: |
-          poetry config virtualenvs.create true --local
-          poetry config virtualenvs.in-project true --local
       - uses: actions/cache@v3
         name: Cache venv
         with:


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Attempt to fix issue seen in other PR where unable to find the Python executable, specifically on Windows.

## CHANGES
<!-- Please explain at a high-level the changes. -->

In the GitHub actions, install `poetry` before `python`.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->