### PR TITLE
Disable windows tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,19 +13,20 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        # NOTE: disabling windows due to failed attempts to install using poetry
+        os: [ ubuntu-latest, macos-latest ]
         python-version: [ "3.14" ]
         include:
-          - os: windows-latest
-            python-version: "3.10"
+          # - os: windows-latest
+          #   python-version: "3.10"
           - os: macos-latest
             python-version: "3.11"
           - os: ubuntu-latest
             python-version: "3.12"
           - os: macos-latest
             python-version: "3.13"
-          - os: windows-latest
-            python-version: "3.13"
+          # - os: windows-latest
+          #   python-version: "3.13"
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Unfortunately, running on Windows is having issues installing project:
```terminal
##[debug]C:\Program Files\PowerShell\7\pwsh.EXE -command ". 'D:\a\_temp\76509626-030a-4d79-a927-8bdac8036e93.ps1'"

Command ['D:\\a\\openapi-spec-tools\\openapi-spec-tools\\.venv\\Scripts\\python.exe', '-I', '-W', 'ignore', '-c', 'import sys\n\nif hasattr(sys, "real_prefix"):\n    print(sys.real_prefix)\nelif hasattr(sys, "base_prefix"):\n    print(sys.base_prefix)\nelse:\n    print(sys.prefix)\n'] errored with the following return code 103

Error output:
did not find executable at 'C:\hostedtoolcache\windows\Python\3.13.12\x64\python.exe': The system cannot find the path specified.
```

So, disabling tests on Windows.

## CHANGES
<!-- Please explain at a high-level the changes. -->

Removed `windows` from test matrix.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->