### PR TITLE
Add oas-history-show to display single commit by hash

### DIFF
--- a/openapi_spec_tools/cli/history.py
+++ b/openapi_spec_tools/cli/history.py
@@ -202,5 +202,54 @@ def commit_changes(
     return
 
 
+@app.command("show", short_help="Show single OAS change in git history.")
+def commit_show(
+    oas_file: OpenApiFilenameArgument,
+    commit: Annotated[
+        str | None,
+        typer.Argument(help="Commit hash"),
+    ],
+    out_fmt: OutputFormatOption = OutputFormat.TABLE,
+    out_style: OutputStyleOption = OutputStyle.ALL,
+):
+    """Show OAS changes over the history of the provided search. The ."""
+    _assert_exists(oas_file)
+    _commit_id = commit.lower()
+    # NOTE: do not filter out commits by other authors, or before start, or will get odd comparisons
+    commits = _find_commits(oas_file=oas_file)
+    columns = ["date", "commit", "changes"]
+    data = []
+    prev_comm = commits[0]
+    prev_data = _read_data(prev_comm, oas_file)
+    for curr_comm in commits[1:]:
+        if _commit_id in prev_comm.hexsha:
+            # because we're walking backward chronologicallly, the prev/curr are different order
+            curr_data = _read_data(curr_comm, oas_file)
+            prev_data = _read_data(prev_comm, oas_file)
+            changes = find_diffs(curr_data, prev_data)
+            if out_fmt == OutputFormat.TABLE:
+                # YAML format is the best looking format for the diffs in a table, so force it
+                changes = yaml.dump(changes).strip()
+            data.append(
+                {
+                    "date": prev_comm.authored_datetime.date().isoformat(),
+                    "commit": prev_comm.hexsha[:7],
+                    "changes": changes,
+                }
+            )
+            break
+
+        prev_comm = curr_comm
+
+    console = console_factory()
+    if not data:
+        console.print("No matching commit found.")
+        return
+
+    config = TableConfig(value_max_len=1000)
+    display(data, fmt=out_fmt, style=out_style, columns=columns, config=config, console=console)
+    return
+
+
 if __name__ == "__main__":
     app()

--- a/tests/cli/test_history.py
+++ b/tests/cli/test_history.py
@@ -13,6 +13,7 @@ from openapi_spec_tools.cli.history import _find_commits
 from openapi_spec_tools.cli.history import _read_data
 from openapi_spec_tools.cli.history import commit_changes
 from openapi_spec_tools.cli.history import commit_history
+from openapi_spec_tools.cli.history import commit_show
 from tests.cli_gen.helpers import to_ascii
 from tests.helpers import StringIo
 from tests.helpers import asset_filename
@@ -328,3 +329,93 @@ def test_commit_changes_failure() -> None:
     ex = context.value
     assert ex.exit_code == 1
     assert FILE_ERROR == mock_stdout.getvalue()
+
+
+MISC_COMMIT_TABLE = """\
+┏━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Date       ┃ Commit  ┃ Changes                      ┃
+┡━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ 2025-06-25 │ 05b302d │ components:                  │
+│            │         │   schemas:                   │
+│            │         │     PetExt:                  │
+│            │         │       allOf[1]:              │
+│            │         │         properties:          │
+│            │         │           listVarious: added │
+└────────────┴─────────┴──────────────────────────────┘
+"""
+MISC_COMMIT_JSON = """\
+[
+  {
+    "date": "2025-06-25",
+    "commit": "05b302d",
+    "changes": {
+      "components": {
+        "schemas": {
+          "PetExt": {
+            "allOf[1]": {
+              "properties": {
+                "listVarious": "added"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+]
+"""
+MISC_COMMIT_NOT_FOUND = """\
+No matching commit found.
+"""
+@pytest.mark.parametrize(
+      ["args", "expected"],
+      [
+        pytest.param(
+            {
+                "oas_file": asset_filename("misc.yaml"),
+                "commit": "05b302d",
+            },
+            MISC_COMMIT_TABLE,
+            id="table",
+        ),
+        pytest.param(
+            {
+                "oas_file": asset_filename("misc.yaml"),
+                "commit": "05b3",
+                "out_fmt": "json",
+            },
+            MISC_COMMIT_JSON,
+            id="json",
+        ),
+        pytest.param(
+            {
+                "oas_file": asset_filename("misc.yaml"),
+                "commit": "05b3abcdef",
+            },
+            MISC_COMMIT_NOT_FOUND,
+            id="not-found",
+        ),
+      ]
+)
+def test_commit_show_success(args: dict[str, Any], expected: str) -> None:
+    with (
+        mock.patch('sys.stdout', new_callable=StringIo) as mock_stdout,
+    ):
+        commit_show(**args)
+
+    result = mock_stdout.getvalue()
+    assert to_ascii(result) == to_ascii(expected)
+
+
+def test_commit_show_failure() -> None:
+    with (
+        mock.patch('sys.stdout', new_callable=StringIo) as mock_stdout,
+        pytest.raises(typer.Exit) as context,
+    ):
+        commit_show(asset_filename("foo.yaml"), "deadbeef")
+
+    ex = context.value
+    assert ex.exit_code == 1
+    assert FILE_ERROR == mock_stdout.getvalue()
+
+


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Add `oas history show` to display single commit changes.


## CHANGES
<!-- Please explain at a high-level the changes. -->

Added new CLI option to history.


<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->