### PR TITLE
Add 'oas history diff'

### DIFF
--- a/openapi_spec_tools/cli/history.py
+++ b/openapi_spec_tools/cli/history.py
@@ -72,6 +72,11 @@ def _author_match(commit: git.Commit, author: str) -> bool:
     return False
 
 
+def _shorthash(commit: git.Commit) -> str:
+    """Get a shortened version of the commit hash."""
+    return commit.hexsha[:7]
+
+
 def _find_commits(
     oas_file: str,
     start: Optional[datetime] = None,
@@ -136,7 +141,7 @@ def commit_history(
     data = [
         {
             "date": _.authored_datetime.date().isoformat(),
-            "commit": _.hexsha[:7],
+            "commit": _shorthash(_),
             "author": _.author.name,
             "message": _.message.strip()[:100],
         }
@@ -180,7 +185,7 @@ def commit_changes(
             data.append(
                 {
                     "date": prev_comm.authored_datetime.date().isoformat(),
-                    "commit": prev_comm.hexsha[:7],
+                    "commit": _shorthash(prev_comm),
                     "changes": changes,
                 }
             )
@@ -207,7 +212,7 @@ def commit_show(
     oas_file: OpenApiFilenameArgument,
     commit: Annotated[
         str | None,
-        typer.Argument(help="Commit hash"),
+        typer.Argument(metavar="HASH", help="Commit hash"),
     ],
     out_fmt: OutputFormatOption = OutputFormat.TABLE,
     out_style: OutputStyleOption = OutputStyle.ALL,

--- a/openapi_spec_tools/cli/history.py
+++ b/openapi_spec_tools/cli/history.py
@@ -256,5 +256,61 @@ def commit_show(
     return
 
 
+@app.command("diff", short_help="Show difference between two points in OAS history.")
+def commit_diff(
+    oas_file: OpenApiFilenameArgument,
+    hash: Annotated[
+        str,
+        typer.Argument(metavar="HASH[..HASH]", help="Commit hash"),
+    ],
+    out_fmt: OutputFormatOption = OutputFormat.TABLE,
+    out_style: OutputStyleOption = OutputStyle.ALL,
+):
+    _assert_exists(oas_file)
+    commits = _find_commits(oas_file=oas_file)
+
+    parts = hash.split("..", maxsplit=1)
+    _start = parts[0].lower()
+    _end = parts[1].lower() if len(parts) > 1 else None
+    if not _end:
+        _end = commits[0].hexsha
+
+    columns = ["commits", "changes"]
+    data = []
+    start_comm = None
+    end_comm = None
+    for curr_comm in commits:
+        if _start in curr_comm.hexsha:
+            start_comm = curr_comm
+        if _end in curr_comm.hexsha:
+            end_comm = curr_comm
+        if start_comm and curr_comm:
+            # because we're walking backward chronologicallly, the prev/curr are different order
+            start_data = _read_data(start_comm, oas_file)
+            end_data = _read_data(end_comm, oas_file)
+            changes = find_diffs(start_data, end_data)
+            if not changes:
+                break
+            if out_fmt == OutputFormat.TABLE:
+                # YAML format is the best looking format for the diffs in a table, so force it
+                changes = yaml.dump(changes).strip()
+            data.append(
+                {
+                    "commits": f"{start_comm.hexsha[:7]}..{end_comm.hexsha[:7]}",
+                    "changes": changes,
+                }
+            )
+            break
+
+    console = console_factory()
+    if not data:
+        console.print("Unable to determine differences.")
+        return
+
+    config = TableConfig(value_max_len=1000)
+    display(data, fmt=out_fmt, style=out_style, columns=columns, config=config, console=console)
+    return
+
+
 if __name__ == "__main__":
     app()

--- a/openapi_spec_tools/cli/history.py
+++ b/openapi_spec_tools/cli/history.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Implement the 'oas-history' CLI commands."""
+import re
 from datetime import datetime
 from datetime import timezone
 from pathlib import Path
@@ -22,6 +23,10 @@ from openapi_spec_tools.cli.arguments import OutputStyle
 from openapi_spec_tools.cli.arguments import OutputStyleOption
 from openapi_spec_tools.cli.utils import error_out
 from openapi_spec_tools.utils import find_diffs
+
+MIN_HASH_LENGTH = 4
+NON_HEX_RE = re.compile(r'[^a-fA-F0-9]')
+
 
 app = typer.Typer(name="history", no_args_is_help=True, short_help="Git history of OAS file")
 
@@ -75,6 +80,19 @@ def _author_match(commit: git.Commit, author: str) -> bool:
 def _shorthash(commit: git.Commit) -> str:
     """Get a shortened version of the commit hash."""
     return commit.hexsha[:7]
+
+
+def _commithash(hash: str) -> str:
+    """Perform basic checks on the provided hash.
+
+    If the hash does NOT meet the standard, an exception is thrown and a meaningful
+    message provided.
+    """
+    if len(hash) < MIN_HASH_LENGTH:
+        error_out(f"Hash must be at least {MIN_HASH_LENGTH} characters")
+    if NON_HEX_RE.search(hash):
+        error_out("Hash must be all hexidecimal characters")
+    return hash.lower()
 
 
 def _find_commits(
@@ -219,7 +237,7 @@ def commit_show(
 ):
     """Show OAS changes over the history of the provided search. The ."""
     _assert_exists(oas_file)
-    _commit_id = commit.lower()
+    _commit_id = _commithash(commit)
     # NOTE: do not filter out commits by other authors, or before start, or will get odd comparisons
     commits = _find_commits(oas_file=oas_file)
     columns = ["date", "commit", "changes"]
@@ -270,8 +288,8 @@ def commit_diff(
     commits = _find_commits(oas_file=oas_file)
 
     parts = hash.split("..", maxsplit=1)
-    _start = parts[0].lower()
-    _end = parts[1].lower() if len(parts) > 1 else None
+    _start = _commithash(parts[0])
+    _end = _commithash(parts[1]) if len(parts) > 1 else None
     if not _end:
         _end = commits[0].hexsha
 

--- a/openapi_spec_tools/utils.py
+++ b/openapi_spec_tools/utils.py
@@ -179,7 +179,7 @@ def find_diffs(lhs: dict[str, Any], rhs: dict[str, Any]) -> dict[str, Any]:
         elif left != right:
             result[k] = f"{shorten_text(str(left))} != {shorten_text(str(right))}"
 
-    return result
+    return {k: result[k] for k in sorted(result.keys())}
 
 
 def count_values(obj: dict[str, Any]) -> int:

--- a/tests/cli/test_history.py
+++ b/tests/cli/test_history.py
@@ -12,6 +12,7 @@ import typer
 from openapi_spec_tools.cli.history import _find_commits
 from openapi_spec_tools.cli.history import _read_data
 from openapi_spec_tools.cli.history import commit_changes
+from openapi_spec_tools.cli.history import commit_diff
 from openapi_spec_tools.cli.history import commit_history
 from openapi_spec_tools.cli.history import commit_show
 from tests.cli_gen.helpers import to_ascii
@@ -419,3 +420,87 @@ def test_commit_show_failure() -> None:
     assert FILE_ERROR == mock_stdout.getvalue()
 
 
+HASH_DELTA1 = "dac5b6d..852fb5b"
+MISC_DIFF1_TABLE = """\
+┏━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Commits          ┃ Changes                     ┃
+┡━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ dac5b6d..852fb5b │ components:                 │
+│                  │   schemas:                  │
+│                  │     Pets:                   │
+│                  │       items: removed        │
+│                  │       maxItems: removed     │
+│                  │       properties: added     │
+│                  │       type: array != object │
+│                  │     ShapeShifter: added     │
+└──────────────────┴─────────────────────────────┘
+"""
+MISC_DIFF1_JSON = """\
+[
+  {
+    "commits": "dac5b6d..852fb5b",
+    "changes": {
+      "components": {
+        "schemas": {
+          "Pets": {
+            "items": "removed",
+            "maxItems": "removed",
+            "properties": "added",
+            "type": "array != object"
+          },
+          "ShapeShifter": "added"
+        }
+      }
+    }
+  }
+]
+"""
+MISC_DIFF1_YAML = """\
+- changes:
+    components:
+      schemas:
+        Pets:
+          items: removed
+          maxItems: removed
+          properties: added
+          type: array != object
+        ShapeShifter: added
+  commits: dac5b6d..852fb5b
+"""
+DIFF_NO_CHANGE = """\
+Unable to determine differences.
+"""
+@pytest.mark.parametrize(
+    ["args", "expected"],
+    [
+        pytest.param({"oas_file": asset_filename("misc.yaml"), "hash": HASH_DELTA1}, MISC_DIFF1_TABLE, id="table"),
+        pytest.param(
+            {"oas_file": asset_filename("misc.yaml"), "hash": HASH_DELTA1, "out_fmt": "json"},
+            MISC_DIFF1_JSON,
+            id="json",
+        ),
+        pytest.param({
+            "oas_file": asset_filename("misc.yaml"), "hash": HASH_DELTA1, "out_fmt": "yaml"},
+            MISC_DIFF1_YAML,
+            id="yaml",
+        ),
+        pytest.param({
+            "oas_file": asset_filename("misc.yaml"), "hash": "dac5b6d..dac5b6d"},
+            DIFF_NO_CHANGE,
+            id="no-change",
+        ),
+        pytest.param({
+            "oas_file": asset_filename("misc.yaml"), "hash": "dac5b6d"},
+            MISC_DIFF1_TABLE,
+            id="no-end",
+        ),
+    ]
+)
+def test_commit_diff_success(args: dict[str, Any], expected: str) -> None:
+    with (
+        mock.patch('sys.stdout', new_callable=StringIo) as mock_stdout,
+    ):
+        commit_diff(**args)
+
+    result = mock_stdout.getvalue()
+    assert to_ascii(result) == to_ascii(expected)

--- a/tests/cli/test_history.py
+++ b/tests/cli/test_history.py
@@ -9,6 +9,7 @@ from unittest import mock
 import pytest
 import typer
 
+from openapi_spec_tools.cli.history import _commithash
 from openapi_spec_tools.cli.history import _find_commits
 from openapi_spec_tools.cli.history import _read_data
 from openapi_spec_tools.cli.history import commit_changes
@@ -23,6 +24,38 @@ from tests.helpers import asset_filename
 START = datetime(2025, 1, 1, tzinfo=timezone.utc)
 END = datetime(2026, 3, 1, tzinfo=timezone.utc)
 FILE_ERROR = "ERROR: Unable to find file\n"
+
+
+@pytest.mark.parametrize(
+    ["hash", "expected"],
+    [
+        pytest.param('b2c6', 'b2c6', id="short"),
+        pytest.param('b2c68ac2afd9b9758560a869d0d4c1ace42f26a2', 'b2c68ac2afd9b9758560a869d0d4c1ace42f26a2', id="long"),
+        pytest.param('B2c68AC', 'b2c68ac', id="caps"),
+    ]
+)
+def test_commithash_success(hash: str, expected: str) -> None:
+    assert expected == _commithash(hash)
+
+
+@pytest.mark.parametrize(
+    ["hash", "message"],
+    [
+        pytest.param("", "Hash must be at least 4 characters", id="short"),
+        pytest.param("not hex", "Hash must be all hexidecimal characters", id="non-hex"),
+        pytest.param("abcd..1234", "Hash must be all hexidecimal characters", id="dots"),
+    ]
+)
+def test_commithash_failure(hash, message) -> None:
+    with (
+        mock.patch('sys.stdout', new_callable=StringIo) as mock_stdout,
+        pytest.raises(typer.Exit) as context,
+    ):
+      _commithash(hash)
+
+    ex = context.value
+    assert ex.exit_code == 1
+    assert f"ERROR: {message}" == mock_stdout.getvalue().strip()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Add `oas history diff` command to compare two versions of the OAS file.

## CHANGES
<!-- Please explain at a high-level the changes. -->

1. Added a couple small `history` utilities to check user-provided hash strings, and get a shortened hash string
2. Update `find_diffs()` to provide a sorted dictionary (allows for consistent test results)
3. Added `commit_diff()` to compare two versions of an OAS file.


<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->