### PR TITLE
Update LayoutNode display

### DIFF
--- a/openapi_spec_tools/layout/types.py
+++ b/openapi_spec_tools/layout/types.py
@@ -103,6 +103,21 @@ class LayoutNode(BaseModel):
     display_columns: list[str] = Field(default_factory=list)
     ignore: Optional[bool] = None
 
+    def display(self, depth: int = 2, max_children: int = 3) -> str:
+        """Display a shorter version of the node."""
+        class_name = self.__class__.__name__
+        items = [
+            self.command,
+            f"id={self.identifier}",
+        ]
+        if self.children:
+            if not depth or len(self.children) > max_children:
+                items.append(f'children={len(self.children)}')
+            else:
+                child_disp = [child.display(depth-1) for child in self.children]
+                items.append(f"children=[{', '.join(child_disp)}]")
+        return f"{class_name}({', '.join(items)})"
+
     def as_dict(self, sparse: bool = True) -> dict[str, Any]:
         """Convert object to dictionary."""
         return self.model_dump(exclude_none=sparse, exclude_unset=sparse, exclude_defaults=sparse)

--- a/openapi_spec_tools/layout/types.py
+++ b/openapi_spec_tools/layout/types.py
@@ -103,6 +103,14 @@ class LayoutNode(BaseModel):
     display_columns: list[str] = Field(default_factory=list)
     ignore: Optional[bool] = None
 
+    def __str__(self):
+        """Display shorter version of LayoutNode."""
+        return self.display()
+
+    def __repr__(self):
+        """Display shorter version of LayoutNode."""
+        return self.display()
+
     def display(self, depth: int = 2, max_children: int = 3) -> str:
         """Display a shorter version of the node."""
         class_name = self.__class__.__name__

--- a/tests/layout/test_layout_types.py
+++ b/tests/layout/test_layout_types.py
@@ -8,6 +8,53 @@ from tests.helpers import asset_filename
 
 
 @pytest.mark.parametrize(
+    ["node", "expected"],
+    [
+        pytest.param(
+            LayoutNode(command="sna", identifier="foo"),
+            "LayoutNode(sna, id=foo)",
+            id="simple",
+        ),
+        pytest.param(
+            LayoutNode(
+                command="sna",
+                identifier="foo",
+                description="This is it",
+                bugs=["abc"],
+                summary_fields=["def"],
+                extra={},
+                pagination=PaginationNames(page_size="10"),
+                reference=ReferenceSubcommand(package="other"),
+                hidden_fields=["field1"],
+                allowed_fields=["field2"],
+                display_columns=["field3"],
+                ignore=True,
+            ),
+            "LayoutNode(sna, id=foo)",
+            id="extra-fields",
+        ),
+        pytest.param(
+            LayoutNode(
+                command="sna",
+                identifier="foo",
+                children=[
+                    LayoutNode(command="a", identifier="A"),
+                    LayoutNode(command="b", identifier="B", children=[LayoutNode(command="x", identifier="X")])
+                ]),
+            (
+                "LayoutNode(sna, id=foo, children=[LayoutNode(a, id=A), "
+                "LayoutNode(b, id=B, children=[LayoutNode(x, id=X)])])"
+            ),
+            id="nested",
+        ),
+    ],
+)
+def test_node_str(node, expected):
+    assert expected == str(node)
+    assert expected == repr(node)
+
+
+@pytest.mark.parametrize(
     ["node", "args", "expected"],
     [
         pytest.param(

--- a/tests/layout/test_layout_types.py
+++ b/tests/layout/test_layout_types.py
@@ -8,6 +8,79 @@ from tests.helpers import asset_filename
 
 
 @pytest.mark.parametrize(
+    ["node", "args", "expected"],
+    [
+        pytest.param(
+            LayoutNode(command="sna", identifier="foo"),
+            {},
+            "LayoutNode(sna, id=foo)",
+            id="simple",
+        ),
+        pytest.param(
+            LayoutNode(
+                command="sna",
+                identifier="foo",
+                description="This is it",
+                bugs=["abc"],
+                summary_fields=["def"],
+                extra={},
+                pagination=PaginationNames(page_size="10"),
+                reference=ReferenceSubcommand(package="other"),
+                hidden_fields=["field1"],
+                allowed_fields=["field2"],
+                display_columns=["field3"],
+                ignore=True,
+            ),
+            {},
+            "LayoutNode(sna, id=foo)",
+            id="extra-fields",
+        ),
+        pytest.param(
+            LayoutNode(
+                command="sna",
+                identifier="foo",
+                children=[
+                    LayoutNode(command="a", identifier="A"),
+                    LayoutNode(command="b", identifier="B", children=[LayoutNode(command="x", identifier="X")])
+                ]),
+            {},
+            (
+                "LayoutNode(sna, id=foo, children=[LayoutNode(a, id=A), "
+                "LayoutNode(b, id=B, children=[LayoutNode(x, id=X)])])"
+            ),
+            id="nested",
+        ),
+        pytest.param(
+            LayoutNode(
+                command="sna",
+                identifier="foo",
+                children=[
+                    LayoutNode(command="a", identifier="A"),
+                    LayoutNode(command="b", identifier="B", children=[LayoutNode(command="x", identifier="X")])
+                ]),
+            {"depth": 1},
+            "LayoutNode(sna, id=foo, children=[LayoutNode(a, id=A), LayoutNode(b, id=B, children=1)])",
+            id="depth",
+        ),
+        pytest.param(
+            LayoutNode(
+                command="sna",
+                identifier="foo",
+                children=[
+                    LayoutNode(command="a", identifier="A"),
+                    LayoutNode(command="b", identifier="B", children=[LayoutNode(command="x", identifier="X")])
+                ]),
+            {"max_children": 1},
+            "LayoutNode(sna, id=foo, children=2)",
+            id="max-children",
+        ),
+    ],
+)
+def test_node_display(node, args, expected):
+    assert expected == node.display(**args)
+
+
+@pytest.mark.parametrize(
     ["node", "sparse", "expected"],
     [
         pytest.param(


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

When debugging, it can be challenging to understand the `LayoutNode` structure. All the details of each node make it difficult to see the structure.

## CHANGES
<!-- Please explain at a high-level the changes. -->

Add/utilize the `LayoutNode.display()` to provide more controls about what is displayed such that the structure is apparent instead of all the details at each layer.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->