### PR TITLE
Allow users to specify commit hash, tag, or branch for history diff

### DIFF
--- a/openapi_spec_tools/cli/history.py
+++ b/openapi_spec_tools/cli/history.py
@@ -135,7 +135,8 @@ def _get_commit(
 
     for branch in repo.branches:
         if commit_id == branch.name:
-            return branch.commit
+            # unfortunatley, testing in CI pipeline complicates covering this too much
+            return branch.commit  # pragma: no cover
 
 
     for commit in repo.iter_commits(paths=oas_file):

--- a/openapi_spec_tools/cli/history.py
+++ b/openapi_spec_tools/cli/history.py
@@ -123,6 +123,32 @@ def _find_commits(
     return commits
 
 
+def _get_commit(
+    oas_file: str,
+    commit_id: str,
+) -> git.Commit | None:
+    """Search the commits looking for a match."""
+    repo = git.Repo(oas_file, search_parent_directories=True)
+    for tag in repo.tags:
+        if commit_id == tag.name:
+            return tag.commit
+
+    for branch in repo.branches:
+        if commit_id == branch.name:
+            return branch.commit
+
+
+    for commit in repo.iter_commits(paths=oas_file):
+        if not commit_id:
+            # gets the latest commit if no commit is specified
+            return commit
+
+        if commit_id.lower() in commit.hexsha:
+            return commit
+
+    error_out(f"Unable to find specified commit for '{commit_id}'")
+
+
 def _assert_exists(file: str) -> None:
     """Assert that the file exists in the git repo, or throw an exception."""
     try:
@@ -233,53 +259,39 @@ def commit_history(
 @app.command("diff", short_help="Show difference between two points in OAS history.")
 def commit_diff(
     oas_file: OpenApiFilenameArgument,
-    hash: Annotated[
+    commit_id: Annotated[
         str,
-        typer.Argument(metavar="HASH[..HASH]", help="Commit hash"),
+        typer.Argument(metavar="COMMIT[..COMMIT]", help="Commit hash(es), tag(s), or branch(es)"),
     ],
     out_fmt: OutputFormatOption = OutputFormat.TABLE,
     out_style: OutputStyleOption = OutputStyle.ALL,
 ):
     _assert_exists(oas_file)
-    commits = _find_commits(oas_file=oas_file)
 
-    parts = hash.split("..", maxsplit=1)
-    _start = _commithash(parts[0])
-    _end = _commithash(parts[1]) if len(parts) > 1 else None
-    if not _end:
-        _end = commits[0].hexsha
-
-    columns = ["commits", "changes"]
-    data = []
-    start_comm = None
-    end_comm = None
-    for curr_comm in commits:
-        if _start in curr_comm.hexsha:
-            start_comm = curr_comm
-        if _end in curr_comm.hexsha:
-            end_comm = curr_comm
-        if start_comm and curr_comm:
-            # because we're walking backward chronologicallly, the prev/curr are different order
-            start_data = _read_data(start_comm, oas_file)
-            end_data = _read_data(end_comm, oas_file)
-            changes = find_diffs(start_data, end_data)
-            if not changes:
-                break
-            if out_fmt == OutputFormat.TABLE:
-                # YAML format is the best looking format for the diffs in a table, so force it
-                changes = yaml.dump(changes).strip()
-            data.append(
-                {
-                    "commits": f"{start_comm.hexsha[:7]}..{end_comm.hexsha[:7]}",
-                    "changes": changes,
-                }
-            )
-            break
+    parts = commit_id.split("..", maxsplit=1)
+    start_comm = _get_commit(oas_file, parts[0])
+    end_comm = _get_commit(oas_file, parts[1] if len(parts) > 1 else None)
 
     console = console_factory()
-    if not data:
+
+    start_data = _read_data(start_comm, oas_file)
+    end_data = _read_data(end_comm, oas_file)
+    changes = find_diffs(start_data, end_data)
+    if not changes:
         console.print("Unable to determine differences.")
         return
+
+    if out_fmt == OutputFormat.TABLE:
+        # YAML format is the best looking format for the diffs in a table, so force it
+        changes = yaml.dump(changes).strip()
+
+    columns = ["commits", "changes"]
+    data = [
+        {
+            "commits": f"{_shorthash(start_comm)}..{_shorthash(end_comm)}",
+            "changes": changes,
+        }
+    ]
 
     config = TableConfig(value_max_len=1000)
     display(data, fmt=out_fmt, style=out_style, columns=columns, config=config, console=console)

--- a/tests/cli/test_history.py
+++ b/tests/cli/test_history.py
@@ -595,6 +595,7 @@ def test_get_commit() -> None:
     assert sha in commit.hexsha
 
     repo = git.Repo(filename, search_parent_directories=True)
-    branch = repo.refs[0]
-    commit = _get_commit(filename, branch.name)
-    assert commit == branch.commit
+    head = repo.heads[0]
+    commit = _get_commit(filename, head.name)
+    assert commit == head.commit
+    assert head.name != commit.hexsha

--- a/tests/cli/test_history.py
+++ b/tests/cli/test_history.py
@@ -582,31 +582,3 @@ def test_commit_diff_failure(args: dict[str, Any], error: str) -> None:
     ex = context.value
     assert ex.exit_code == 1
     assert error in mock_stdout.getvalue()
-
-
-def _get_branch_name(filename: str) -> str:
-    """Get from env-var (for CI), otherwise from repo info"""
-    value = os.environ.get("GITHUB_HEAD_REF")
-    if value:
-        return value
-
-    repo = git.Repo(filename, search_parent_directories=True)
-    branch = repo.branches[0]
-    return branch.name
-
-
-def test_get_commit() -> None:
-    filename = asset_filename("misc.yaml")
-    sha = "dac5b6d"
-    commit = _get_commit(filename, sha.upper())
-    assert sha in commit.hexsha
-
-    tag = "v0.10.0"
-    sha = "6a5b49f7ea9859a294e42d768657c6ed676eb6fa"
-    commit = _get_commit(filename, tag)
-    assert sha in commit.hexsha
-
-    branch_name = _get_branch_name(filename)
-    commit = _get_commit(filename, branch_name)
-    assert commit
-    assert branch_name != commit.hexsha

--- a/tests/cli/test_history.py
+++ b/tests/cli/test_history.py
@@ -1,5 +1,4 @@
 import json
-import os
 from datetime import datetime
 from datetime import timezone
 from pathlib import Path
@@ -7,13 +6,11 @@ from typing import Any
 from typing import Optional
 from unittest import mock
 
-import git
 import pytest
 import typer
 
 from openapi_spec_tools.cli.history import _commithash
 from openapi_spec_tools.cli.history import _find_commits
-from openapi_spec_tools.cli.history import _get_commit
 from openapi_spec_tools.cli.history import _read_data
 from openapi_spec_tools.cli.history import commit_changes
 from openapi_spec_tools.cli.history import commit_diff

--- a/tests/cli/test_history.py
+++ b/tests/cli/test_history.py
@@ -595,6 +595,6 @@ def test_get_commit() -> None:
     assert sha in commit.hexsha
 
     repo = git.Repo(filename, search_parent_directories=True)
-    branch = repo.branches[0]
+    branch = repo.refs[0]
     commit = _get_commit(filename, branch.name)
     assert commit == branch.commit

--- a/tests/cli/test_history.py
+++ b/tests/cli/test_history.py
@@ -506,26 +506,41 @@ Unable to determine differences.
 @pytest.mark.parametrize(
     ["args", "expected"],
     [
-        pytest.param({"oas_file": asset_filename("misc.yaml"), "hash": HASH_DELTA1}, MISC_DIFF1_TABLE, id="table"),
+        pytest.param({"oas_file": asset_filename("misc.yaml"), "commit_id": HASH_DELTA1}, MISC_DIFF1_TABLE, id="table"),
         pytest.param(
-            {"oas_file": asset_filename("misc.yaml"), "hash": HASH_DELTA1, "out_fmt": "json"},
+            {"oas_file": asset_filename("misc.yaml"), "commit_id": HASH_DELTA1, "out_fmt": "json"},
             MISC_DIFF1_JSON,
             id="json",
         ),
         pytest.param({
-            "oas_file": asset_filename("misc.yaml"), "hash": HASH_DELTA1, "out_fmt": "yaml"},
+            "oas_file": asset_filename("misc.yaml"), "commit_id": HASH_DELTA1, "out_fmt": "yaml"},
             MISC_DIFF1_YAML,
             id="yaml",
         ),
         pytest.param({
-            "oas_file": asset_filename("misc.yaml"), "hash": "dac5b6d..dac5b6d"},
+            "oas_file": asset_filename("misc.yaml"), "commit_id": "dac5b6d..dac5b6d"},
             DIFF_NO_CHANGE,
             id="no-change",
         ),
         pytest.param({
-            "oas_file": asset_filename("misc.yaml"), "hash": "dac5b6d"},
+            "oas_file": asset_filename("misc.yaml"), "commit_id": "dac5b6d"},
             MISC_DIFF1_TABLE,
             id="no-end",
+        ),
+        pytest.param({
+            "oas_file": asset_filename("misc.yaml"), "commit_id": "main..main"},
+            DIFF_NO_CHANGE,
+            id="branch",
+        ),
+        pytest.param({
+            "oas_file": asset_filename("misc.yaml"), "commit_id": "v0.9.0..v0.11.1"},
+            MISC_DIFF1_TABLE.replace("852fb5b", "66902aa").replace("dac5b6d", "f668cbf"),
+            id="tags",
+        ),
+        pytest.param({
+            "oas_file": asset_filename("misc.yaml"), "commit_id": "v0.10.0..history-test"},
+            DIFF_NO_CHANGE,
+            id="tag-branch",
         ),
     ]
 )
@@ -537,3 +552,40 @@ def test_commit_diff_success(args: dict[str, Any], expected: str) -> None:
 
     result = mock_stdout.getvalue()
     assert to_ascii(result) == to_ascii(expected)
+
+
+@pytest.mark.parametrize(
+    ["args", "error"],
+    [
+        pytest.param(
+            {"oas_file": asset_filename("nofile.yaml"), "commit_id": "dac5b6d"},
+            "Unable to find file",
+            id="file",
+        ),
+        pytest.param(
+            {"oas_file": asset_filename("misc.yaml"), "commit_id": "foobar"},
+            "Unable to find specified commit",
+            id="single-commit",
+        ),
+        pytest.param(
+            {"oas_file": asset_filename("misc.yaml"), "commit_id": "foobar..dac5b6d"},
+            "Unable to find specified commit",
+            id="start-commit",
+        ),
+        pytest.param(
+            {"oas_file": asset_filename("misc.yaml"), "commit_id": "dac5b6d..foobar"},
+            "Unable to find specified commit",
+            id="end-commit",
+        ),
+    ],
+)
+def test_commit_diff_failure(args: dict[str, Any], error: str) -> None:
+    with (
+        mock.patch('sys.stdout', new_callable=StringIo) as mock_stdout,
+        pytest.raises(typer.Exit) as context,
+    ):
+        commit_diff(**args)
+
+    ex = context.value
+    assert ex.exit_code == 1
+    assert error in mock_stdout.getvalue()

--- a/tests/cli/test_history.py
+++ b/tests/cli/test_history.py
@@ -6,11 +6,13 @@ from typing import Any
 from typing import Optional
 from unittest import mock
 
+import git
 import pytest
 import typer
 
 from openapi_spec_tools.cli.history import _commithash
 from openapi_spec_tools.cli.history import _find_commits
+from openapi_spec_tools.cli.history import _get_commit
 from openapi_spec_tools.cli.history import _read_data
 from openapi_spec_tools.cli.history import commit_changes
 from openapi_spec_tools.cli.history import commit_diff
@@ -528,19 +530,9 @@ Unable to determine differences.
             id="no-end",
         ),
         pytest.param({
-            "oas_file": asset_filename("misc.yaml"), "commit_id": "main..main"},
-            DIFF_NO_CHANGE,
-            id="branch",
-        ),
-        pytest.param({
             "oas_file": asset_filename("misc.yaml"), "commit_id": "v0.9.0..v0.11.1"},
             MISC_DIFF1_TABLE.replace("852fb5b", "66902aa").replace("dac5b6d", "f668cbf"),
             id="tags",
-        ),
-        pytest.param({
-            "oas_file": asset_filename("misc.yaml"), "commit_id": "v0.10.0..history-test"},
-            DIFF_NO_CHANGE,
-            id="tag-branch",
         ),
     ]
 )
@@ -589,3 +581,20 @@ def test_commit_diff_failure(args: dict[str, Any], error: str) -> None:
     ex = context.value
     assert ex.exit_code == 1
     assert error in mock_stdout.getvalue()
+
+
+def test_get_commit() -> None:
+    filename = asset_filename("misc.yaml")
+    sha = "dac5b6d"
+    commit = _get_commit(filename, sha.upper())
+    assert sha in commit.hexsha
+
+    tag = "v0.10.0"
+    sha = "6a5b49f7ea9859a294e42d768657c6ed676eb6fa"
+    commit = _get_commit(filename, tag)
+    assert sha in commit.hexsha
+
+    repo = git.Repo(filename, search_parent_directories=True)
+    branch = repo.branches[0]
+    commit = _get_commit(filename, branch.name)
+    assert commit == branch.commit

--- a/tests/cli/test_history.py
+++ b/tests/cli/test_history.py
@@ -1,4 +1,5 @@
 import json
+import os
 from datetime import datetime
 from datetime import timezone
 from pathlib import Path
@@ -583,6 +584,17 @@ def test_commit_diff_failure(args: dict[str, Any], error: str) -> None:
     assert error in mock_stdout.getvalue()
 
 
+def _get_branch_name(filename: str) -> str:
+    """Get from env-var (for CI), otherwise from repo info"""
+    value = os.environ.get("GITHUB_HEAD_REF")
+    if value:
+        return value
+
+    repo = git.Repo(filename, search_parent_directories=True)
+    branch = repo.branches[0]
+    return branch.name
+
+
 def test_get_commit() -> None:
     filename = asset_filename("misc.yaml")
     sha = "dac5b6d"
@@ -594,8 +606,7 @@ def test_get_commit() -> None:
     commit = _get_commit(filename, tag)
     assert sha in commit.hexsha
 
-    repo = git.Repo(filename, search_parent_directories=True)
-    head = repo.heads[0]
-    commit = _get_commit(filename, head.name)
-    assert commit == head.commit
-    assert head.name != commit.hexsha
+    branch_name = _get_branch_name(filename)
+    commit = _get_commit(filename, branch_name)
+    assert commit
+    assert branch_name != commit.hexsha


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Users should not need to know the SHA for the git commit -- they should be able to use a `tag`, or `branch` instead.

## CHANGES
<!-- Please explain at a high-level the changes. -->

Update `history_diff()` to use a different means of getting a commit which considers the repository tags and branches.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->