### PR TITLE
Allow user to specify hardcoded values in layout

### DIFF
--- a/openapi_spec_tools/cli/layout.py
+++ b/openapi_spec_tools/cli/layout.py
@@ -25,6 +25,7 @@ from openapi_spec_tools.layout.layout_generator import LayoutGenerator
 from openapi_spec_tools.layout.merge import merge
 from openapi_spec_tools.layout.types import LayoutNode
 from openapi_spec_tools.layout.utils import DEFAULT_START
+from openapi_spec_tools.layout.utils import check_hardcoded
 from openapi_spec_tools.layout.utils import check_pagination_definitions
 from openapi_spec_tools.layout.utils import file_to_tree
 from openapi_spec_tools.layout.utils import operation_duplicates
@@ -57,6 +58,7 @@ def layout_check_format(
     op_dups: Annotated[bool, typer.Option(help="Check for duplicate names in sub-commands")] = True,
     op_order: Annotated[bool, typer.Option(help="Check the operations order within each sub-command")] = True,
     pagination: Annotated[bool, typer.Option(help="Check the pagination parameters for issues")] = True,
+    hardcoded: Annotated[bool, typer.Option(help="Check the hardCoded parameters")] = True,
     log_level: LogLevelOption = "info",
 ) -> None:
     logger = init_logging(log_level, LOG_CLASS)
@@ -104,6 +106,12 @@ def layout_check_format(
         errors = check_pagination_definitions(data)
         if errors:
             typer.echo(f"Pagination parameter errors:{_dict_to_str(errors)}")
+            result = 1
+
+    if hardcoded:
+        errors = check_hardcoded(data)
+        if errors:
+            typer.echo(f"Hardcoded parameter errors:{_dict_to_str(errors)}")
             result = 1
 
     if result:

--- a/openapi_spec_tools/cli_gen/cli_generator.py
+++ b/openapi_spec_tools/cli_gen/cli_generator.py
@@ -168,28 +168,46 @@ if __name__ == "__main__":
         typer_decl = f"{typer_type}({comma.join(typer_args)}"
         return f'{var_name}: Annotated[{py_type}, {typer_decl})]{arg_default}'
 
-    def op_path_arguments(self, path_params: list[dict[str, Any]]) -> list[str]:
+    def op_path_arguments(
+        self,
+        path_params: list[dict[str, Any]],
+        hardcoded: dict[str, Any] | None = None,
+    ) -> list[str]:
         """Convert all path parameters into typer arguments."""
         args = []
         for param in path_params:
+            if hardcoded and param.get(OasField.NAME) in hardcoded:
+                continue
             arg = self.property_to_argument(param, allow_required=True)
             args.append(arg)
 
         return args
 
-    def op_query_arguments(self, query_params: list[dict[str, Any]]) -> list[str]:
+    def op_query_arguments(
+        self,
+        query_params: list[dict[str, Any]],
+        hardcoded: dict[str, Any] | None = None,
+    ) -> list[str]:
         """Convert query parameters to typer arguments."""
         args = []
         for param in query_params:
+            if hardcoded and param.get(OasField.NAME) in hardcoded:
+                continue
             arg = self.property_to_argument(param, allow_required=False)
             args.append(arg)
 
         return args
 
-    def op_body_arguments(self, body_params: list[dict[str, Any]]) -> list[str]:
+    def op_body_arguments(
+        self,
+        body_params: dict[str, Any],
+        hardcoded: dict[str, Any] | None = None,
+    ) -> list[str]:
         """Convert the body parameters dictionary into a list of CLI function arguments."""
         args = []
         for prop_name, prop_data in body_params.items():
+            if hardcoded and prop_name in hardcoded:
+                continue
             prop_data[OasField.NAME.value] = prop_name
             arg = self.property_to_argument(prop_data, allow_required=False)
             args.append(arg)
@@ -252,6 +270,19 @@ if __name__ == "__main__":
 
         args = [quoted(v) for v in node.display_columns]
         return f"{SEP1}columns = [{', '.join(args)}]"
+
+    def initialize_hardcoded(
+        self,
+        hardcoded: dict[str, Any],
+    ) -> str:
+        """Initialize any hard-coded variables in the function."""
+        if not hardcoded:
+            return ""
+
+        lines = ["# initialize hard-coded values"]
+        for name, value in hardcoded.items():
+            lines.append(f"{self.variable_name(name)} = {maybe_quoted(value)}")
+        return NL + SEP1 + SEP1.join(lines)
 
     def pagination_creation(self, command: LayoutNode) -> str:
         """Create the 'page_info' variable."""
@@ -325,16 +356,17 @@ if __name__ == "__main__":
 
         func_name = self.function_name(node.identifier)
         func_args = []
-        func_args.extend(self.op_path_arguments(path_params))
-        func_args.extend(self.op_query_arguments(query_params))
-        func_args.extend(self.op_query_arguments(header_params))
-        func_args.extend(self.op_body_arguments(body_params))
+        func_args.extend(self.op_path_arguments(path_params, node.hardcoded))
+        func_args.extend(self.op_query_arguments(query_params, node.hardcoded))
+        func_args.extend(self.op_query_arguments(header_params, node.hardcoded))
+        func_args.extend(self.op_body_arguments(body_params, node.hardcoded))
         func_args.extend(self.command_infra_arguments(node))
         args_str = SEP1 + f",{SEP1}".join(func_args) + "," + NL
 
         command_args.append(f'short_help="{self.op_short_help(op)}"')
         self.logger.debug(f"{func_name}({len(path_params)} path, {len(query_params)} query, {len(body_params)} body)")
 
+        hardcoded_values = self.initialize_hardcoded(node.hardcoded)
         user_header_init = ""
         user_header_arg = ""
         if header_params:
@@ -352,7 +384,7 @@ if __name__ == "__main__":
 @app.command({', '.join(command_args)})
 def {func_name}({args_str}) -> None:
     {self.op_doc_string(op)}# handler for {node.identifier}: {method} {path}
-    _l.init_logging(_log_level){deprecation_warning}{user_header_init}
+    _l.init_logging(_log_level){deprecation_warning}{hardcoded_values}{user_header_init}
     headers = _r.request_headers(_api_key{self.op_content_header(op)}{user_header_arg})
     url = _r.create_url({self.op_url_params(path)}){self.pagination_creation(node)}{columns}
     missing = {self.op_check_missing(query_params + header_params, body_params)}

--- a/openapi_spec_tools/layout/types.py
+++ b/openapi_spec_tools/layout/types.py
@@ -23,6 +23,7 @@ class LayoutField(str, Enum):
     IGNORE = "ignore"
     COLUMNS = "columns"
     REFERENCE = "reference"
+    HARDCODED = "hardCoded"
 
 
 class PaginationField(str, Enum):
@@ -86,6 +87,13 @@ class ReferenceSubcommand(BaseModel):
     app_name: str = "app"
 
 
+class HardcodedField(str, Enum):
+    """Field names for reference to hard-coded values."""
+
+    NAME = "name"
+    VALUE = "value"
+
+
 class LayoutNode(BaseModel):
     """Info for handling the layout file in a hierachical fashion."""
 
@@ -102,6 +110,7 @@ class LayoutNode(BaseModel):
     allowed_fields: list[str] = Field(default_factory=list)
     display_columns: list[str] = Field(default_factory=list)
     ignore: bool | None = None
+    hardcoded: dict[str, Any] = Field(default_factory=dict)
 
     def __str__(self):
         """Display shorter version of LayoutNode."""

--- a/openapi_spec_tools/layout/utils.py
+++ b/openapi_spec_tools/layout/utils.py
@@ -307,6 +307,42 @@ def check_pagination_definitions(data: dict[str, Any]) -> dict[str, str]:
     return errors
 
 
+def check_hardcoded(data: dict[str, Any]) -> dict[str, str]:
+    """Check for issues within the hardcoded parameters."""
+    errors = {}
+    required_values = (HardcodedField.NAME.value, HardcodedField.VALUE.value)
+    all_values = (HardcodedField.NAME.value, HardcodedField.VALUE.value)
+
+    for sub_name, _sub_data in data.items():
+        sub_data = _sub_data or {}
+        for op_data in sub_data.get(LayoutField.OPERATIONS, []):
+            hard_params = op_data.get(LayoutField.HARDCODED)
+            if not hard_params:
+                continue
+
+            full_name = f"{sub_name}.{op_data.get(LayoutField.NAME)}"
+            if not isinstance(hard_params, list):
+                errors[full_name] = "must be a list of parameter name/values"
+                continue
+
+            reasons = []
+            for index, item in enumerate(hard_params):
+                if not isinstance(item, dict):
+                    reasons.append(f"index#{index} must be a dictionary")
+                    continue
+                missing = {key for key in required_values if key not in item}
+                if missing:
+                    reasons.append(f"index#{index} missing {', '.join(missing)}")
+                extra_keys = [k for k in item.keys() if k not in all_values]
+                if extra_keys:
+                    reasons.append(f"index#{index} unsupported parameters: {', '.join(extra_keys)}")
+
+            if reasons:
+                errors[full_name] = '; '.join(reasons)
+
+    return errors
+
+
 def file_to_tree(filename: str, start: str = DEFAULT_START) -> LayoutNode:
     """Open filename and parse to a LayoutNode tree."""
     data = open_layout(filename)

--- a/openapi_spec_tools/layout/utils.py
+++ b/openapi_spec_tools/layout/utils.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import yaml
 
+from openapi_spec_tools.layout.types import HardcodedField
 from openapi_spec_tools.layout.types import LayoutField
 from openapi_spec_tools.layout.types import LayoutNode
 from openapi_spec_tools.layout.types import PaginationField
@@ -89,6 +90,24 @@ def parse_reference(data: dict[str, Any] | None) -> ReferenceSubcommand | None:
     )
 
 
+def parse_hardcoded(data: dict[str, Any] | None) -> dict[str, Any]:
+    """Parse the data into dictionary of name to value."""
+    if not data:
+        return {}
+
+    if not isinstance(data, list):
+        return {}
+
+    result = {}
+    for item in data:
+        name = item.get(HardcodedField.NAME)
+        value = item.get(HardcodedField.VALUE)
+        if name and value is not None:
+            result[name] = value
+
+    return result
+
+
 def data_to_node(data: dict[str, Any], identifier: str, command: str, item: dict[str, Any]) -> LayoutNode:
     """Recursively convert elements from data to LayoutNodes."""
     description = item.get(LayoutField.DESCRIPTION, "")
@@ -103,6 +122,7 @@ def data_to_node(data: dict[str, Any], identifier: str, command: str, item: dict
     pagination = parse_pagination(item.get(LayoutField.PAGINATION))
     ignore = item.get(LayoutField.IGNORE)
     reference = parse_reference(item.get(LayoutField.REFERENCE))
+    hardcoded = parse_hardcoded(item.get(LayoutField.HARDCODED))
 
     children = []
     for op_data in item.get(LayoutField.OPERATIONS, []):
@@ -133,6 +153,7 @@ def data_to_node(data: dict[str, Any], identifier: str, command: str, item: dict
         pagination=pagination,
         ignore=ignore,
         reference=reference,
+        hardcoded=hardcoded,
     )
 
 
@@ -285,6 +306,7 @@ def check_pagination_definitions(data: dict[str, Any]) -> dict[str, str]:
 
     return errors
 
+
 def file_to_tree(filename: str, start: str = DEFAULT_START) -> LayoutNode:
     """Open filename and parse to a LayoutNode tree."""
     data = open_layout(filename)
@@ -344,6 +366,8 @@ def layout_node_to_dict(node: LayoutNode) -> dict[str, Any]:
             op_data[LayoutField.PAGINATION.value] = pagination_to_dict(child.pagination)
         if child.reference:
             op_data[LayoutField.REFERENCE.value] = reference_to_dict(child.reference)
+        if child.hardcoded:
+            op_data[LayoutField.HARDCODED.value] = dict(sorted(child.hardcoded.items()))
         operations.append(op_data)
 
     result = {

--- a/tests/assets/layout_bad.yaml
+++ b/tests/assets/layout_bad.yaml
@@ -21,6 +21,8 @@ pets:
       operationId: deletePetById
     - name: examine
       subcommandId: pets_examine
+    - name: health
+      subcommandId: pets_health
 
 pets_examine:
   description: Examine your pet
@@ -29,6 +31,14 @@ pets_examine:
       operationId: checkPetBloodPressure
     - name: heart-rate
       operationId: checkPetHeartRate
+
+pets_health:
+  description: Some health stuff
+  operations:
+    - name: someOperation
+      operationId: whoKnows
+      hardCoded:
+        - name: foo
 
 owners:
   # no description, or opertations
@@ -51,4 +61,3 @@ veterinarians:
   operations:
     - name: add
     - name: delete
-

--- a/tests/assets/layout_hardcoded.yaml
+++ b/tests/assets/layout_hardcoded.yaml
@@ -1,0 +1,26 @@
+main:
+  description: Pet management application
+  operations:
+    - name: pet
+      subcommandId: pets
+
+pets:
+  description: Manage your pets
+  operations:
+    - name: create
+      operationId: createPets
+      hardCoded:
+      - name: name
+        value: toulouse
+    - name: delete
+      operationId: deletePetById
+      hardCoded:
+      - name: id
+      - value: 1
+      - name: sna
+        value: foo
+    - name: examine
+      subcommandId: pets_examine
+      hardCoded: my string
+    - name: update
+      operationId: showPetById

--- a/tests/cli/test_layout.py
+++ b/tests/cli/test_layout.py
@@ -28,7 +28,7 @@ Unused sub-commands for:
 """
 ERR_SUB_ORDER = """\
 Sub-commands are misordered:
-    owners < pets_examine
+    owners < pets_health
 """
 ERR_OPS_PROPS = """\
 Sub-commands have missing properties:
@@ -42,12 +42,16 @@ Duplicate operations in sub-commands:
 ERR_OPS_ORDER = """\
 Sub-command operation orders should be:
     main: owners, pet, shows, vets
-    pets: create, delete, examine, update
+    pets: create, delete, examine, health, update
     shelters: list, list, rescue
 """
 ERR_PAGINATION = """\
 Pagination parameter errors:
     shelters.list: cannot have next URL in both header and body property
+"""
+ERR_HARDCODED = """\
+Hardcoded parameter errors:
+    pets_health.someOperation: index#0 missing value
 """
 
 
@@ -60,6 +64,7 @@ def args_disabled(updates: dict[str, Any]) -> dict[str, Any]:
         "op_dups": False,
         "op_order": False,
         "pagination": False,
+        "hardcoded": False,
     }
 
     values = options.copy()
@@ -80,6 +85,7 @@ def args_disabled(updates: dict[str, Any]) -> dict[str, Any]:
                 ERR_OPS_DUPES,
                 ERR_OPS_ORDER,
                 ERR_PAGINATION,
+                ERR_HARDCODED,
             ]),
             id="all"
         ),
@@ -112,6 +118,11 @@ def args_disabled(updates: dict[str, Any]) -> dict[str, Any]:
             args_disabled({"pagination": True}),
             ERR_PAGINATION,
             id="pagination",
+        ),
+        pytest.param(
+            args_disabled({"hardcoded": True}),
+            ERR_HARDCODED,
+            id="hardcoded",
         ),
     ]
 )

--- a/tests/cli_gen/test_cli_generator.py
+++ b/tests/cli_gen/test_cli_generator.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -96,6 +97,12 @@ def test_op_path_arguments():
     assert 'situation: Annotated' not in text
     assert 'more: Annotated' not in text
 
+    # retest with some hard-coded parameters
+    lines = uut.op_path_arguments(path_params, {"mustHave": None, "species": "frog"})
+    text = "\n".join(lines)
+    assert "species: Annotated" not in text
+    assert "mustHave: Annotated" not in text
+
 
 def test_op_query_arguments():
     oas = open_oas(asset_filename("misc.yaml"))
@@ -192,6 +199,12 @@ def test_op_query_arguments():
     assert 'num_feet: Annotated' not in text
     assert 'must_have: Annotated' not in text
 
+    # retest with some hardcoded params
+    lines = uut.op_query_arguments(properties, {"favoriteDay": "1776-07-04", "addr.city": "San Fran"})
+    text = "\n".join(lines)
+    assert "favorite_day: Annotated" not in text
+    assert "addr_city: Annotated" not in text
+
 
 def test_op_body_arguments():
     oas = open_oas(asset_filename("misc.yaml"))
@@ -259,6 +272,12 @@ def test_op_body_arguments():
     # make sure read-only not included
     assert 'id: Annotated' not in text
 
+    # retest with some hardcoded params
+    lines = uut.op_body_arguments(body_params, {"format": 1, "optionalList": None})
+    text = "\n".join(lines)
+    assert "format_: Annotated" not in text
+    assert "optional_list: Annotated" not in text
+
 
 @pytest.mark.parametrize(
     ["names", "expected"],
@@ -305,6 +324,26 @@ def test_pagination_creation(names, expected) -> None:
     uut = CliGenerator("foo", {})
     result = uut.pagination_creation(node)
     assert expected == result.strip()
+
+
+@pytest.mark.parametrize(
+    ["hardcoded", "expected"],
+    [
+        pytest.param({"node": 1}, 'node = 1', id="number"),
+        pytest.param({"fooBar": "snaFoo"}, 'foo_bar = "snaFoo"', id="camel"),
+        pytest.param({"foo": True}, 'foo = True', id="True"),
+        pytest.param({"foo": False}, 'foo = False', id="False"),
+        pytest.param({"sna": None}, 'sna = None', id="None"),
+        pytest.param({"node": []}, 'node = []', id="list-empty"),
+        pytest.param({"node": ['value1', 'item2']}, "node = ['value1', 'item2']", id="list-str"),
+    ],
+)
+def test_hardcoded(hardcoded: dict[str, Any], expected: str) -> None:
+    uut = CliGenerator("foo", {})
+    text = uut.initialize_hardcoded(hardcoded)
+    assert "# initialize hard-coded values" in text
+    assert expected in text
+
 
 @pytest.mark.parametrize(
     ["command", "has_details"],
@@ -451,6 +490,13 @@ def test_function_definition_forced_single():
     assert "_out_fmt: _a.OutputFormatOption" in text
     assert "_out_style: _a.OutputStyleOption" in text
 
+    # check a couple of the args
+    assert 'attachments_id: Annotated[str | None, typer.Option(show_default=False)] = None,' in text
+    assert (
+        'attachments_edge_color: Annotated[Color | None, typer.Option(show_default=False, case_sensitive=False)] = None'
+        in text
+    )
+
     # no summary field, so no details flag
     assert "_details: _a.DetailsOption" not in text
 
@@ -473,6 +519,18 @@ def test_function_definition_forced_single():
     # make sure the missing parameter checks are present
     assert 'missing.append("--api-key")' in text
     assert ' _e.handle_exceptions(_e.MissingRequiredError(missing))' in text
+
+    # more testing with hardcoded parameters
+    item.hardcoded = {
+        "attachments.id": "deadbeef",
+        "attachments.edgeColor": "green",
+    }
+    text = uut.function_definition(item)
+    assert 'attachments_id: Annotated[' not in text
+    assert 'attachments_edge_color: Annotated[' not in text
+    assert '# initialize hard-coded values' in text
+    assert 'attachments_id = "deadbeef"' in text
+    assert 'attachments_edge_color = "green"' in text
 
 
 def test_function_definition_paged():
@@ -569,6 +627,14 @@ def test_function_header_params():
     assert 'if has_param is None:' in text
     assert 'missing.append("--has-param")' in text
     assert ' _e.handle_exceptions(_e.MissingRequiredError(missing))' in text
+
+    # test with a hardcoded header parameter
+    item.hardcoded["hasParam"] = 23
+    text = uut.function_definition(item)
+    assert "has_param: Annotated" not in text  # no more function parameter
+    assert "# initialize hard-coded values" in text
+    assert "has_param = 23" in text  # initialization
+    assert "if has_param is None" in text  # still checks missing
 
 
 def test_main():

--- a/tests/layout/test_layout_types.py
+++ b/tests/layout/test_layout_types.py
@@ -147,6 +147,7 @@ def test_node_display(node, args, expected):
                 'description': '',
                 'display_columns': [],
                 'extra': {},
+                'hardcoded': {},
                 'hidden_fields': [],
                 'identifier': 'foo',
                 'ignore': None,

--- a/tests/layout/test_layout_utils.py
+++ b/tests/layout/test_layout_utils.py
@@ -12,6 +12,7 @@ from openapi_spec_tools.layout.utils import operation_duplicates
 from openapi_spec_tools.layout.utils import operation_order
 from openapi_spec_tools.layout.utils import pagination_to_dict
 from openapi_spec_tools.layout.utils import parse_extras
+from openapi_spec_tools.layout.utils import parse_hardcoded
 from openapi_spec_tools.layout.utils import parse_pagination
 from openapi_spec_tools.layout.utils import parse_to_tree
 from openapi_spec_tools.layout.utils import path_to_parts
@@ -234,6 +235,27 @@ def test_path_to_parts(path, prefix, expected):
 )
 def test_parse_pagination(data, expected) -> None:
     assert expected == parse_pagination(data)
+
+
+@pytest.mark.parametrize(
+    ["data", "expected"],
+    [
+        pytest.param(None, {}, id="none"),
+        pytest.param("not a list", {}, id="str"),
+        pytest.param({"A": None}, {}, id="dict"),
+        pytest.param([], {}, id="empty"),
+        pytest.param([{"name": "a", "value": 1}], {"a": 1}, id="simple"),
+        pytest.param([{"name": "a", "value": 1}, {"name": "b", "value": True}], {"a": 1, "b": True}, id="multiple"),
+        pytest.param(
+            [{"value": 1}, {"name": "b"}, {"name": "c", "value": "mystr"}, {"d": 0}],
+            {"c": "mystr"},
+            id="bad-entries",
+        ),
+    ]
+)
+def test_parse_hardcoded(data, expected) -> None:
+    assert expected == parse_hardcoded(data)
+
 
 @pytest.mark.parametrize(
     [NAME, "item", "expected"],
@@ -609,7 +631,8 @@ def test_layout_node_to_dict():
                 display_columns=["west", "east"]
             ),
             LayoutNode(command="child1", identifier="my_child", pagination=PaginationNames(page_size="page")),
-            LayoutNode(command="child2", identifier="another_op", ignore=True)
+            LayoutNode(command="child2", identifier="another_op", ignore=True),
+            LayoutNode(command="child4", identifier="with_hardcoded", hardcoded={"c": True, "x": "y", "a": 1}),
         ]
     )
     actual = layout_node_to_dict(node)
@@ -635,7 +658,12 @@ def test_layout_node_to_dict():
                     "hiddenFields": ["peekaboo"],
                     "summaryFields": ["brief", "short"],
                     "columns": ["west", "east"],
-                }
+                },
+                {
+                    "hardCoded": {"a": 1, "c": True, "x": "y"},
+                    "name": "child4",
+                    "operationId": "with_hardcoded",
+                },
             ]
         }
     }

--- a/tests/layout/test_layout_utils.py
+++ b/tests/layout/test_layout_utils.py
@@ -258,6 +258,22 @@ def test_parse_hardcoded(data, expected) -> None:
 
 
 @pytest.mark.parametrize(
+    ["name", "expected"],
+    [
+        pytest.param("update", {}, id="none"),
+        pytest.param("create", {"name": "toulouse"}, id="simple"),
+        pytest.param("delete", {"sna": "foo"}, id="errors"),
+        pytest.param("examine", {}, id="bad"),
+    ]
+)
+def test_parse_with_hardcoded(name, expected) -> None:
+    node = file_to_tree(asset_filename("layout_hardcoded.yaml"))
+
+    item = node.find("pet", name)
+    assert expected == item.hardcoded
+
+
+@pytest.mark.parametrize(
     [NAME, "item", "expected"],
     [
         pytest.param(

--- a/tests/layout/test_layout_utils.py
+++ b/tests/layout/test_layout_utils.py
@@ -2,6 +2,7 @@ import pytest
 
 from openapi_spec_tools.layout.types import LayoutNode
 from openapi_spec_tools.layout.types import PaginationNames
+from openapi_spec_tools.layout.utils import check_hardcoded
 from openapi_spec_tools.layout.utils import check_pagination_definitions
 from openapi_spec_tools.layout.utils import data_to_node
 from openapi_spec_tools.layout.utils import field_to_list
@@ -29,6 +30,8 @@ PAGE = "pagination"
 SUB_ID = "subcommandId"
 REF = "reference"
 ONE_OF_MSG = f"{OP_ID}, {SUB_ID}, or {REF}"
+HARD = "hardCoded"
+VALUE = "value"
 
 
 def test_open_layout() -> None:
@@ -512,6 +515,45 @@ def test_subcommand_order(data, start, expected) -> None:
 )
 def test_pagination_definitions(data, expected) -> None:
     assert expected == check_pagination_definitions(data)
+
+
+@pytest.mark.parametrize(
+    ["data", "expected"],
+    [
+        pytest.param(
+            {"a": {OPS: [{NAME: "foo"}]}},
+            {},
+            id="no-hard",
+        ),
+        pytest.param(
+            {"b": {OPS: [{NAME: "foo", HARD: [{NAME: "sna", VALUE: "bar"}]}]}},
+            {},
+            id="simple",
+        ),
+        pytest.param(
+            {"c": {OPS: [{NAME: "foo", HARD: {NAME: "sna", VALUE: "bar"}}]}},
+            {"c.foo": "must be a list of parameter name/values"},
+            id="non-list",
+        ),
+        pytest.param(
+            {"d": {OPS: [{NAME: "foo", HARD: ["sna: bar"]}]}},
+            {"d.foo": "index#0 must be a dictionary"},
+            id="non-dict",
+        ),
+        pytest.param(
+            {"e": {OPS: [{NAME: "foo", HARD: [{NAME: "sna"}, {VALUE: 1}]}]}},
+            {"e.foo": "index#0 missing value; index#1 missing name"},
+            id="missing",
+        ),
+        pytest.param(
+            {"f": {OPS: [{NAME: "foo", HARD: [{NAME: "sna", VALUE: "foo", "a": 1}]}]}},
+            {"f.foo": "index#0 unsupported parameters: a"},
+            id="unsupported",
+        ),
+    ],
+)
+def test_check_hardcoded(data, expected) -> None:
+    assert expected == check_hardcoded(data)
 
 
 def test_lists() -> None:


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

Allow users to specify hard-coded values in their layout, such that the CLI has no option to set the value.

## CHANGES
<!-- Please explain at a high-level the changes. -->

* Added a `hardCoded` parameter to the layout node, so users can specify `name`/`value` pairs.
* Added linting to check that each `hardCoded` value has both `name` and `value`.
* Updated CLI generator to skip putting CLI arguments for hardcded parameters, and initialize the "parameters" with the provided values.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->