### PR TITLE
Update actions to work with windows-latest

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,10 +13,10 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-2022, macos-latest ]
+        os: [ ubuntu-latest, windows-lastest, macos-latest ]
         python-version: [ "3.14" ]
         include:
-          - os: windows-2022
+          - os: windows-lastest
             python-version: "3.10"
           - os: macos-latest
             python-version: "3.11"
@@ -24,7 +24,7 @@ jobs:
             python-version: "3.12"
           - os: macos-latest
             python-version: "3.13"
-          - os: windows-2022
+          - os: windows-lastest
             python-version: "3.13"
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,16 +41,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install poetry
-        uses: abatilo/actions-poetry@v4
-      - name: Setup a virtual environment
-        run: |
-          poetry config virtualenvs.create true --local
-          poetry config virtualenvs.in-project true --local
-      - uses: actions/cache@v3
-        name: Cache venv
+        uses: snok/install-poetry@v1
         with:
-          path: ./.venv
-          key: venv-${{ hashFiles('poetry.lock') }}
+          version: 1.8.3
+          virtualenvs-create: true
+          virtualenvs-in-project: true
       - name: Install the project dependencies
         run: poetry install
       - name: Test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,10 +13,10 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-lastest, macos-latest ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
         python-version: [ "3.14" ]
         include:
-          - os: windows-lastest
+          - os: windows-latest
             python-version: "3.10"
           - os: macos-latest
             python-version: "3.11"
@@ -24,7 +24,7 @@ jobs:
             python-version: "3.12"
           - os: macos-latest
             python-version: "3.13"
-          - os: windows-lastest
+          - os: windows-latest
             python-version: "3.13"
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,8 +47,10 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
       - name: Install the project dependencies
+        shell: bash
         run: poetry install
       - name: Test
+        shell: bash
         run: poetry run coverage run -m pytest --showlocals -v tests
         env:
           COVERAGE_FILE: coverage/.coverage.${{ runner.os }}-py${{ matrix.python-version }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,10 +13,10 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest, windows-2022, macos-latest ]
         python-version: [ "3.14" ]
         include:
-          - os: windows-latest
+          - os: windows-2022
             python-version: "3.10"
           - os: macos-latest
             python-version: "3.11"
@@ -24,7 +24,7 @@ jobs:
             python-version: "3.12"
           - os: macos-latest
             python-version: "3.13"
-          - os: windows-latest
+          - os: windows-2022
             python-version: "3.13"
       fail-fast: false
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## RATIONALE
<!--
For best reviews, please explain why this change is being done. It is not always obvious
from the code, and the folks reviewing may not respond quickly.
-->

The `windows-latest` does not seem to be able to find Python. 

In [this example](https://github.com/rickwporter/openapi-spec-tools/actions/runs/28057169387/job/83062284888?pr=210), we get the following error:
```terminal
Error output:
did not find executable at 'C:\hostedtoolcache\windows\Python\3.14.5\x64\python.exe': The system cannot find the path specified.
```

## CHANGES
<!-- Please explain at a high-level the changes. -->

Update the GH actions to use `windows-2022` instead of `windows-latest`.

<!-- Recommended addition sections:
## TESTING
## SCREENSHOTS
## NOTES
## TODO
## RELATED
## REVIEWERS

-->